### PR TITLE
fixed .env problem, can start sever/conenct to db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-server/config/config.env
+.env

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "server/server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "SET NODE_ENV=production & node server/server",
+    "dev": "nodemon server/server"
   },
   "repository": {
     "type": "git",

--- a/server/server.js
+++ b/server/server.js
@@ -8,8 +8,10 @@ const hpp = require('hpp');
 const configureCors = require('./config/CorsConfig');
 import DBConfig from './config/DBConfig';
 
-// Load environment variables
-dotenv.config({ path: './config/config.env' });
+// // Load environment variables
+dotenv.config();
+// NOTE I had to move the .env file to the top level, because for some reason I couldn't access process.env.whatever when the .env file was within the config folder.  So moved it out, renamed the folder to db and just called the file .env
+// dotenv.config({ path: './config/config.env' });
 
 // Initial server setup
 const app = express();


### PR DESCRIPTION
So I had to do a little reconfiguration.  I had to move the .env file to the top level of the app because for some reason when it was within the 'config/config.env' locaiton, the sever wasn't able to access 'process.env.whatever' and so therefore I couldn't connect the db because the 'CONNECTION_STRING' was undefined.  Even though I thought I properly configured the dotenv path (see server.js file notes) it wasn't working.  So I moved it to the top level and it's working now.  We can successfully connect to the db and start/run the server.