### PR TITLE
changed port number, can now get photos

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -3,11 +3,7 @@ import Vuex from 'vuex';
 import axios from 'axios';
 
 Vue.use(Vuex);
-// let base = window.location.host.includes('localhost')
-//   ? '//localhost:8080/'
-//   : '/';
 
-// let api = axios.create({ baseURL: base + 'api/' });
 let base = window.location.host.includes('localhost:8080')
   ? '//localhost:3000/'
   : '/';

--- a/server/main.js
+++ b/server/main.js
@@ -18,7 +18,7 @@ Startup.ConfigureRoutes(app);
 DBConfig.connectDB();
 
 // Starting up the server
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 3000;
 const server = app.listen(PORT, () =>
   console.log(
     `Server is running in ${process.env.NODE_ENV} mode on port ${PORT}.`


### PR DESCRIPTION
I had set the port number in the server to 5000 and the client was coming from 'localhost:3000' (with 3000 being the specified port number), and so of course the request were never making it to the server because the ports were different.  So I changed the port number in the server to 3000 and now we can get photos.  