### PR TITLE
can get winners/losers and render in table

### DIFF
--- a/client/src/components/FinanceComponent.vue
+++ b/client/src/components/FinanceComponent.vue
@@ -11,31 +11,30 @@
     </div>
     <div class="bodySection">
       <div class="mainViewSection">
-        <div class="fake">
-          <h5>fake header for now</h5>
-          <p>
-            fake text for now. Lorem ipsum dolor sit amet consectetur,
-            adipisicing elit. Aliquid doloremque, possimus consequuntur
-            accusantium ipsa architecto reiciendis pariatur voluptatibus? Cum
-            voluptate in hic enim mollitia pariatur saepe ducimus molestias quo
-            aut.
-          </p>
-        </div>
-        <div class="fake2">
-          <h4>kdjfkd</h4>
-          <p>fake fake lorem</p>
-          <p>
-            Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quae esse
-            adipisci quis ea dolor, animi fugit dolore velit vel. Nam voluptas
-            enim sapiente voluptatem dicta harum voluptatum minima similique
-            nostrum. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-            Ipsa labore quis repellat fugiat sint, distinctio quae. Modi, animi!
-            Magni libero repellendus quibusdam aperiam reprehenderit consequatur
-            ipsam ipsa eos animi ipsum! Lorem ipsum, dolor sit amet.
-          </p>
-        </div>
-
         <!-- This is where the data for the different header elements/topics will appear. This is also where the data for a specific stock will be displayed when a user clicks on a stock (may end up creating a little mini component to handle specified stock data) -->
+        <div class="winnersLosers">
+          <div class="mainSectionHeader">
+            <h4>Day Winners and Losers</h4>
+          </div>
+          <div class="winLoseTable">
+            <table>
+              <tr>
+                <th>Symbol</th>
+                <th>Stock Name</th>
+                <th>Current Price</th>
+                <th>Day High</th>
+                <th>Day Low</th>
+                <th>% Change</th>
+                <th>Exchange Name</th>
+              </tr>
+              <finance-table
+                v-for="stock in financeWinnersLosers"
+                :key="stock.symbol"
+                :stockData="stock"
+              />
+            </table>
+          </div>
+        </div>
       </div>
       <div class="newsSection container-fluid">
         <!-- This is where the list for the news articles will go, goal is to create a mini-pagination effect to loop through articles -->
@@ -73,8 +72,12 @@
 </template>
 
 <script>
+import FinanceTable from '@/components/FinanceWinLoseTable.vue';
 export default {
   name: 'FinanceCompoenent',
+  components: {
+    FinanceTable,
+  },
   data() {
     return {
       firstNews: true,
@@ -88,6 +91,15 @@ export default {
     financeNews() {
       this.checkNews();
       return this.$store.state.currentFinanceNews;
+    },
+    financeWinners() {
+      return this.$store.state.financeWinners;
+    },
+    financeLosers() {
+      return this.$store.state.financeLosers;
+    },
+    financeWinnersLosers() {
+      return this.$store.state.financeWinnersLosers;
     },
   },
   methods: {
@@ -140,6 +152,28 @@ export default {
 .mainViewSection {
   width: 600px;
 }
+.mainSectionHeader h4 {
+  text-align: center;
+  position: relative;
+  padding-bottom: 5px;
+}
+.mainSectionHeader h4::after {
+  position: absolute;
+  content: '';
+  width: 60%;
+  height: 2px;
+  left: 20%;
+  bottom: 0;
+  background: white;
+}
+
+/* Winners/Losers styling */
+.winLoseTable {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+/* News section styling */
 .newsSection {
   max-width: 250px;
   display: flex;

--- a/client/src/components/FinanceWinLoseTable.vue
+++ b/client/src/components/FinanceWinLoseTable.vue
@@ -1,0 +1,47 @@
+<template>
+  <tr>
+    <td>{{ stockData.symbol }}</td>
+    <td>{{ stockData.longName }}</td>
+    <td>{{ stockData.regularMarketPrice }}</td>
+    <td>{{ stockData.regularMarketDayHigh }}</td>
+    <td>{{ stockData.regularMarketDayLow }}</td>
+    <td :class="{ positive: isPositive, negative: !isPositive }">
+      {{ stockData.regularMarketChangePercent }}
+    </td>
+    <td>{{ stockData.fullExchangeName }}</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'WinLoseTableComponent',
+  props: ['stockData'],
+  data() {
+    return {
+      isPositive: false,
+    };
+  },
+  mounted() {
+    if (this.stockData.positive == true) {
+      this.isPositive = true;
+    } else {
+      this.isPositive = false;
+    }
+  },
+  computed: {},
+  methods: {},
+};
+</script>
+
+<style scoped>
+tr {
+  border-top: 1pt solid black;
+  border-bottom: 1pt solid black;
+}
+.positive {
+  color: green;
+}
+.negative {
+  color: red;
+}
+</style>

--- a/client/src/components/NewsModal.vue
+++ b/client/src/components/NewsModal.vue
@@ -72,6 +72,7 @@ export default {
   mounted() {
     // this.$store.dispatch('getNews');
     this.$store.dispatch('getFinanceNews');
+    this.$store.dispatch('getWinnersLosers');
   },
   computed: {},
   methods: {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -27,6 +27,9 @@ export default new Vuex.Store({
     newsNoPicture: [],
     currentFinanceNews: [],
     allFinanceNews: [],
+    financeWinners: [],
+    financeLosers: [],
+    financeWinnersLosers: [],
   },
   mutations: {
     //#region --Photo Methods--
@@ -124,6 +127,16 @@ export default new Vuex.Store({
       console.log('after the swtich', state.currentFinanceNews);
       console.log(state.allFinanceNews);
     },
+    setWinners(state, winners) {
+      state.financeWinners = winners;
+    },
+    setLosers(state, losers) {
+      state.financeLosers = losers;
+    },
+    setWinnersLosers(state, combined) {
+      state.financeWinnersLosers = combined;
+    },
+
     //#endregion
   },
   actions: {
@@ -334,6 +347,27 @@ export default new Vuex.Store({
         finish: indexOfNewsToFind,
       };
       commit('setNewFinanceNews', indexes);
+    },
+    async getWinnersLosers({ commit }) {
+      let win = await api.get('finance/win');
+      let lose = await api.get('finance/lose');
+      commit('setWinners', win.data.quotes);
+      console.log('winners', win.data.quotes);
+      commit('setLosers', lose.data.quotes);
+      console.log('losers', lose.data.quotes);
+      let combined = [];
+      combined.push(win.data.quotes);
+      combined.push(lose.data.quotes.reverse());
+      let combinedFlat = combined.flat();
+      combinedFlat.forEach((s) => {
+        if (Math.sign(s.regularMarketChangePercent) == 1) {
+          s.positive = true;
+        } else if (Math.sign(s.regularMarketChangePercent) == -1) {
+          s.positive = false;
+        }
+      });
+      console.log('combined', combinedFlat);
+      commit('setWinnersLosers', combinedFlat);
     },
     //#endregion
   },

--- a/server/controllers/FinanceController.js
+++ b/server/controllers/FinanceController.js
@@ -4,12 +4,31 @@ import { financeService } from '../services/FinanceService';
 export class FinanceController extends BaseController {
   constructor() {
     super('api/finance');
-    this.router.get('/news', this.getFinanceNews);
+    this.router
+      .get('/news', this.getFinanceNews)
+      .get('/win', this.getFinanceWinners)
+      .get('/lose', this.getFinanceLosers);
   }
 
   async getFinanceNews(req, res, next) {
     try {
       let data = await financeService.getFinanceNews();
+      return res.status(200).send(data.data);
+    } catch (error) {
+      next(error);
+    }
+  }
+  async getFinanceWinners(req, res, next) {
+    try {
+      let data = await financeService.getFinanceWinners();
+      return res.status(200).send(data.data);
+    } catch (error) {
+      next(error);
+    }
+  }
+  async getFinanceLosers(req, res, next) {
+    try {
+      let data = await financeService.getFinanceLosers();
       return res.status(200).send(data.data);
     } catch (error) {
       next(error);

--- a/server/services/FinanceService.js
+++ b/server/services/FinanceService.js
@@ -19,6 +19,44 @@ class FinanceService {
       );
     }
   }
+  async getFinanceWinners() {
+    try {
+      return await axios({
+        method: 'GET',
+        url:
+          'https://yahoo-finance15.p.rapidapi.com/api/yahoo/co/collections/day_gainers',
+        params: { start: '0' },
+        headers: {
+          'x-rapidapi-key': process.env.X_RAPIDAPI_KEY,
+          'x-rapidapi-host': 'yahoo-finance15.p.rapidapi.com',
+        },
+      });
+    } catch (error) {
+      throw new ErrorResponse(
+        `Unable to get finance winners. ${error}`,
+        error.response.status
+      );
+    }
+  }
+  async getFinanceLosers() {
+    try {
+      return await axios({
+        method: 'GET',
+        url:
+          'https://yahoo-finance15.p.rapidapi.com/api/yahoo/co/collections/day_losers',
+        params: { start: '0' },
+        headers: {
+          'x-rapidapi-key': process.env.X_RAPIDAPI_KEY,
+          'x-rapidapi-host': 'yahoo-finance15.p.rapidapi.com',
+        },
+      });
+    } catch (error) {
+      throw new ErrorResponse(
+        `Unable to get finance losers. ${error}`,
+        error.response.status
+      );
+    }
+  }
 }
 
 export const financeService = new FinanceService();


### PR DESCRIPTION
Can fetch winners and losers for percent change for the day, can render the results in a single table. Had to do some configuration of the data in the 'actions' section before sending the winner/loser data to the 'mutation' section.  The percent changed column will change color based on positive or negative percentage. One thing to come back to is to try to figure out how to get row titles to stay fixed when scrolling through the table.  Next step is to move onto 'trending' tab of finance section.