### PR TITLE
Creating finance component

### DIFF
--- a/client/src/components/FinanceComponent.vue
+++ b/client/src/components/FinanceComponent.vue
@@ -78,13 +78,11 @@ export default {
       },
     };
   },
-  mounted() {
-    // this.$store.dispatch('getFinanceNews');
-  },
+  mounted() {},
   computed: {
     financeNews() {
       this.checkNews();
-      return this.$store.state.currentFinanceNews;
+      return this.$store.state.finance.currentFinanceNews;
     },
   },
   methods: {
@@ -92,16 +90,12 @@ export default {
       if (this.$store.state.finance.currentFinanceNews.length < 10) {
         this.lastNews = true;
         this.firstNews = false;
-        console.log(this.firstNews);
-        console.log(this.lastNews);
       } else if (
-        this.$store.state.finances.currentFinanceNews[0] ==
-        this.$store.state.finances.allFinanceNews[0]
+        this.$store.state.finance.currentFinanceNews[0] ==
+        this.$store.state.finance.allFinanceNews[0]
       ) {
         this.firstNews = true;
         this.lastNews = false;
-        console.log(this.firstNews);
-        console.log(this.lastNews);
       }
     },
     nextNews() {

--- a/client/src/components/FinanceComponent.vue
+++ b/client/src/components/FinanceComponent.vue
@@ -13,9 +13,9 @@
       <div class="mainViewSection">
         <!-- NOTE the 'main view' area, where the different tabs' data will be displayed -->
         <finance-win-lose v-if="show.winLose" />
-        <finance-undervalued v-else-if="show.undervalued" />
-        <finance-technology v-else-if="show.technology" />
-        <finance-growers v-else-if="show.growers" />
+        <finance-tab v-if="show.undervalued" :componentData="undervalued" />
+        <finance-tab v-if="show.technology" :componentData="technology" />
+        <finance-tab v-if="show.growers" :componentData="growers" />
       </div>
       <div class="newsSection container-fluid">
         <!-- This is where the list for the news articles will go, goal is to create a mini-pagination effect to loop through articles -->
@@ -54,17 +54,13 @@
 
 <script>
 import FinanceWinLose from '@/components/FinanceWinLose.vue';
-import FinanceUndervalued from '@/components/FinanceUndervalued.vue';
-import FinanceTechnology from '@/components/FinanceTechnology.vue';
-import FinanceGrowers from '@/components/FinanceGrowers.vue';
+import FinanceTab from '@/components/FinanceTabs.vue';
 
 export default {
   name: 'FinanceCompoenent',
   components: {
     FinanceWinLose,
-    FinanceUndervalued,
-    FinanceTechnology,
-    FinanceGrowers,
+    FinanceTab,
   },
   data() {
     return {
@@ -75,6 +71,30 @@ export default {
         undervalued: false,
         technology: false,
         growers: false,
+      },
+      winLose: {
+        title: 'Winners/Losers',
+        desc:
+          'Some of the days biggest movers, both positive and negative, based on the percent change of the price of the stock today compared to at closing yesterday.',
+        type: 'winLose',
+      },
+      technology: {
+        title: 'Technology Stocks',
+        desc:
+          'These are some techonology stocks whose earnings growth is greater than 25%.',
+        type: 'technology',
+      },
+      undervalued: {
+        title: 'Potentially undervalued stocks',
+        desc:
+          'These are some stocks whose earnings have grown more than 25%, and have a relatively low Price-to-Earnings Ratio (which is good) which means that they may be currently undervalued.',
+        type: 'undervalued',
+      },
+      growers: {
+        title: 'Small Cap Stocks',
+        desc:
+          'These are some other small cap stocks whose earnings growth percentage is greater than 25%.',
+        type: 'growers',
       },
     };
   },
@@ -150,7 +170,8 @@ export default {
 .navbar {
 }
 .navbar p {
-  margin: 7px 0;
+  font-size: 18px;
+  margin: 5px 0;
 }
 .navbar p:hover {
   cursor: pointer;

--- a/client/src/components/FinanceTable.vue
+++ b/client/src/components/FinanceTable.vue
@@ -2,13 +2,13 @@
   <tr>
     <td>{{ stockData.symbol }}</td>
     <td>{{ stockData.longName }}</td>
-    <td>{{ stockData.regularMarketPrice }}</td>
-    <td>{{ stockData.fiftyDayAverage }}</td>
-    <td>{{ stockData.twoHundredDayAverage }}</td>
+    <td>{{ stockData.regularMarketPrice.toFixed(2) }}</td>
+    <td>{{ stockData.fiftyDayAverage.toFixed(2) }}</td>
+    <td>{{ stockData.twoHundredDayAverage.toFixed(2) }}</td>
     <td class="range">
       {{ stockData.fiftyTwoWeekRange }}
     </td>
-    <td>{{ stockData.epsTrailingTwelveMonths }}</td>
+    <td>{{ stockData.epsTrailingTwelveMonths.toFixed(2) }}</td>
   </tr>
 </template>
 

--- a/client/src/components/FinanceTabs.vue
+++ b/client/src/components/FinanceTabs.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="financeTab">
+    <div class="header">
+      <h4>{{ componentData.title }}</h4>
+      <p>
+        {{ componentData.desc }}
+      </p>
+    </div>
+    <div v-if="componentData.type == 'technology'" class="financeTable">
+      <table>
+        <tr>
+          <th>Symbol</th>
+          <th>Stock Name</th>
+          <th>Current Price</th>
+          <th>50d Avg</th>
+          <th>200d Avg</th>
+          <th class="range">52wk Rng</th>
+          <th>52wk EPS</th>
+        </tr>
+        <finance-table
+          v-for="stock in Technology"
+          :key="stock.symbol"
+          :stockData="stock"
+        />
+      </table>
+    </div>
+    <div
+      v-if="componentData.type == 'undervalued'"
+      style="max-height: 342px; overflow-y: auto"
+    >
+      <table>
+        <tr>
+          <th>Symbol</th>
+          <th>Stock Name</th>
+          <th>Current Price</th>
+          <th>50d Avg</th>
+          <th>200d Avg</th>
+          <th class="range">52wk Rng</th>
+          <th>52wk EPS</th>
+        </tr>
+        <finance-table
+          v-for="stock in Undervalued"
+          :key="stock.symbol"
+          :stockData="stock"
+        />
+      </table>
+    </div>
+    <div
+      v-if="componentData.type == 'growers'"
+      style="max-height: 365px; overflow-y: auto"
+    >
+      <table>
+        <tr>
+          <th>Symbol</th>
+          <th>Stock Name</th>
+          <th>Current Price</th>
+          <th>50d Avg</th>
+          <th>200d Avg</th>
+          <th class="range">52wk Rng</th>
+          <th>52wk EPS</th>
+        </tr>
+        <finance-table
+          v-for="stock in Growers"
+          :key="stock.symbol"
+          :stockData="stock"
+        />
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import FinanceTable from '@/components/FinanceTable.vue';
+export default {
+  name: 'FinanceTabs',
+  props: ['componentData'],
+  components: {
+    FinanceTable,
+  },
+  computed: {
+    Technology() {
+      return this.$store.state.finance.technology;
+    },
+    Undervalued() {
+      return this.$store.state.finance.undervalued;
+    },
+    Growers() {
+      return this.$store.state.finance.growers;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.header {
+  text-align: center;
+}
+.header h4 {
+  margin-bottom: 0;
+}
+.header p {
+  position: relative;
+  padding: 0 5px 5px 5px;
+  font-size: 15px;
+  margin-bottom: 3px;
+}
+.header p::after {
+  position: absolute;
+  content: '';
+  width: 60%;
+  height: 2px;
+  left: 20%;
+  bottom: 0;
+  background: white;
+}
+.range {
+  width: 90px;
+}
+.financeTable {
+  max-height: 385px;
+  overflow-y: auto;
+}
+</style>

--- a/client/src/components/FinanceWinLose.vue
+++ b/client/src/components/FinanceWinLose.vue
@@ -4,8 +4,8 @@
       <h4>Day Winners and Losers</h4>
       <p>
         Some of the day's biggest movers, both positive and negative, based on
-        the percent change of the price of the stock today compared to atclosing
-        yesterday.
+        the percent change of the price of the stock today compared to at
+        closing yesterday.
       </p>
     </div>
     <div class="winLoseTable">

--- a/client/src/components/NewsModal.vue
+++ b/client/src/components/NewsModal.vue
@@ -33,6 +33,17 @@
 
           <div class="modal-footer">
             <slot name="footer">
+              <p v-if="showNews" class="sourceLink">
+                Powered by
+                <a href="https://www.bing.com/" target="_blank">Bing</a>
+              </p>
+              <p v-if="showFinance" class="sourceLink">
+                Powered by
+                <a href="https://finance.yahoo.com/" target="_blank"
+                  >Yahoo Finance</a
+                >
+              </p>
+              <p v-if="showSports" class="sourceLink">Powered by</p>
               <button
                 class="modal-default-button"
                 @click="$emit('close-news-modal')"
@@ -155,6 +166,10 @@ h2:hover {
   /* overflow-y: auto; */
 }
 
+.modal-footer {
+  display: flex;
+  justify-content: space-between;
+}
 .modal-default-button {
   float: right;
 }

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -119,8 +119,8 @@ export default new Vuex.Store({
 
     //#region --Finance Methods--
     setFinanceNews(state, news) {
-      state.currentFinanceNews = news.slice(0, 10);
-      state.allFinanceNews = news;
+      state.finance.currentFinanceNews = news.slice(0, 10);
+      state.finance.allFinanceNews = news;
     },
     setNewFinanceNews(state, indexes) {
       state.finance.currentFinanceNews = state.finance.allFinanceNews.slice(
@@ -338,9 +338,9 @@ export default new Vuex.Store({
       commit('setFinanceNews', res.data);
     },
     nextNews({ commit, state }) {
-      let lastElementIndex = state.currentFinanceNews.length - 1;
-      let newsToFind = state.currentFinanceNews[lastElementIndex];
-      let indexOfNewsToFind = state.allFinanceNews.indexOf(newsToFind);
+      let lastElementIndex = state.finance.currentFinanceNews.length - 1;
+      let newsToFind = state.finance.currentFinanceNews[lastElementIndex];
+      let indexOfNewsToFind = state.finance.allFinanceNews.indexOf(newsToFind);
 
       let indexes = {
         start: indexOfNewsToFind + 1,
@@ -349,8 +349,8 @@ export default new Vuex.Store({
       commit('setNewFinanceNews', indexes);
     },
     previousNews({ commit, state }) {
-      let newsToFind = state.currentFinanceNews[0];
-      let indexOfNewsToFind = state.allFinanceNews.indexOf(newsToFind);
+      let newsToFind = state.finance.currentFinanceNews[0];
+      let indexOfNewsToFind = state.finance.allFinanceNews.indexOf(newsToFind);
 
       let indexes = {
         start: indexOfNewsToFind - 10,

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -378,26 +378,14 @@ export default new Vuex.Store({
     },
     async getUndervalued({ commit }) {
       let res = await api.get('finance/undervalued');
-      res.data.quotes.forEach((s) => {
-        s.twoHundredDayAverage = s.twoHundredDayAverage.toFixed(2);
-        s.fiftyDayAverage = s.fiftyDayAverage.toFixed(2);
-      });
       commit('setUndervalued', res.data.quotes);
     },
     async getTechnology({ commit }) {
       let res = await api.get('finance/technology');
-      res.data.quotes.forEach((s) => {
-        s.twoHundredDayAverage = s.twoHundredDayAverage.toFixed(2);
-        s.fiftyDayAverage = s.fiftyDayAverage.toFixed(2);
-      });
       commit('setTechnology', res.data.quotes);
     },
     async getGrowers({ commit }) {
       let res = await api.get('finance/growers');
-      res.data.quotes.forEach((s) => {
-        s.twoHundredDayAverage = s.twoHundredDayAverage.toFixed(2);
-        s.fiftyDayAverage = s.fiftyDayAverage.toFixed(2);
-      });
       commit('setGrowers', res.data.quotes);
     },
     //#endregion


### PR DESCRIPTION
I noticed that the other 3 finance tabs besides 'winners/losers' all used the same exact table had the same formatting so I decided to consolidate them into one more general FinanceTab component. Where the title and description of the tab are determined and passed down to the general FinanceTab component from it's parent, the FinanceComponent.  From there, the FinanceTab component renders the given data, and then based on the data passed down, will fetch and display the reqresuite financial data.  This pull request still includes the now useless 3 separate financial tab components, I wanted to keep them include with this commit just in case I need to go back or need them for some reason; USE THIS COMMIT!