### PR TITLE
can delete last user properly

### DIFF
--- a/client/src/components/Greeting.vue
+++ b/client/src/components/Greeting.vue
@@ -96,6 +96,7 @@ export default {
     submitNewUser() {
       this.$store.dispatch('newUser', this.user);
       this.noUser = false;
+      this.user.name = '';
     },
 
     // Check for last 'logged in' user when first starting the app
@@ -141,6 +142,7 @@ export default {
           this.$store.dispatch('deleteUserById', id);
           this.$store.dispatch('getAllUsers');
           Swal.fire('Deleted!', 'The user has been deleted.', 'success');
+          this.noUser = true;
         }
       });
     },

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -68,6 +68,9 @@ export default new Vuex.Store({
     setUsers(state, users) {
       state.users = users;
     },
+    resetUser(state) {
+      state.user = null;
+    },
     //#endregion
 
     //#region --Todo Methods--
@@ -239,6 +242,9 @@ export default new Vuex.Store({
     async getAllUsers({ commit }) {
       let res = await api.get('users');
       commit('setUsers', res.data);
+      if (res.data.length == 0) {
+        commit('resetUser');
+      }
     },
     async getUserById({ commit }, id) {
       let res = await api.get('users/' + id);

--- a/server/controllers/UsersController.js
+++ b/server/controllers/UsersController.js
@@ -1,5 +1,6 @@
 import BaseController from '../utils/BaseController';
 import { userService } from '../services/UserService';
+import { lastUserService } from '../services/LastUserService';
 import { photoService } from '../services/PhotoService';
 import { quoteService } from '../services/QuoteService';
 import { todoService } from '../services/TodoService';
@@ -87,6 +88,7 @@ export class UsersController extends BaseController {
   async deleteUserById(req, res, next) {
     try {
       await userService.deleteUserById(req.params.id);
+      await lastUserService.deleteUserById(req.params.id);
       return res.status(200).send('Successfully deleted');
     } catch (error) {
       next(error);

--- a/server/services/LastUserService.js
+++ b/server/services/LastUserService.js
@@ -39,6 +39,21 @@ class LastUserService {
       );
     }
   }
+  async deleteUserById(id) {
+    try {
+      let lastUser = await dbContext.LastUser.findOne({});
+      if (lastUser._id == id) {
+        return await dbContext.LastUser.findByIdAndDelete(id);
+      } else {
+        return 'Ids do not match';
+      }
+    } catch (error) {
+      throw new ErrorResponse(
+        `Cant find user with that id ${user.id}.  ${error}`,
+        error.response.status
+      );
+    }
+  }
 }
 
 export const lastUserService = new LastUserService();


### PR DESCRIPTION
Set it up so where if you are the last user, and you delete yourself, it will properly delete the lastUser object from the lastUser collection (before it wasn't being touched). Also ensured that if you are the last user and you delete yourself that the user object in the client store is reset, which is utilized to better enhance the UX of the Greeting Component; in that before even though we were deleting the object from the database, nothing was telling the local store to update and therefore the newly deleted User object in the store was still there and so the component would still render its data. Next is continuing to test use cases and different scenarios of deleting users to make sure the core functionality hasn't been changed.