### PR TITLE
reconfigured todos

### DIFF
--- a/client/src/components/Todo.vue
+++ b/client/src/components/Todo.vue
@@ -75,7 +75,10 @@
         </div>
         <div class="todoItems">
           <div class="todos" v-if="todoListSelected == 'Todos'">
-            <div class="noTodos" v-if="this.$store.state.todos.length == 0">
+            <div
+              class="noTodos"
+              v-if="this.$store.state.todo.todos.length == 0"
+            >
               <p>
                 You don't have any todos, click the button below to create one.
               </p>
@@ -110,7 +113,7 @@
           >
             <div
               class="noTodos"
-              v-if="this.$store.state.completedTodos.length == 0"
+              v-if="this.$store.state.todo.completedTodos.length == 0"
             >
               <p>
                 You don't have any completed todos, time to get to work!
@@ -143,7 +146,7 @@
           <div class="customListTodos" v-else>
             <div
               class="noTodos"
-              v-if="this.$store.state.customListTodos.length == 0"
+              v-if="this.$store.state.todo.customListTodos.length == 0"
             >
               <p>
                 You don't have any todos, click the button below to create one.
@@ -226,24 +229,28 @@ export default {
     };
   },
   mounted() {
-    this.$store.dispatch('getTodosByUserId', this.$store.state.user.id);
-    this.$store.dispatch('getTodoListsByUserId', this.$store.state.user.id);
+    this.$store.dispatch('getTodosByUserId', this.$store.state.user.user.id);
+    this.$store.dispatch(
+      'getTodoListsByUserId',
+      this.$store.state.user.user.id
+    );
   },
   computed: {
     Todos() {
-      return this.$store.state.todos;
+      return this.$store.state.todo.todos;
     },
     CompletedTodos() {
-      return this.$store.state.completedTodos;
+      return this.$store.state.todo.completedTodos;
     },
     TodoLists() {
-      return this.$store.state.usersTodoLists;
+      return this.$store.state.todo.usersTodoLists;
     },
     CustomListTodos() {
-      return this.$store.state.customListTodos;
+      return this.$store.state.todo.customListTodos;
     },
   },
   methods: {
+    //#region --Helper Methods--
     toggleTodoInput() {
       if (this.showTodoInput) {
         this.showTodoInput = false;
@@ -268,14 +275,14 @@ export default {
 
     //#region --Todo Methods--
     submitTodo() {
-      this.todo.userId = this.$store.state.user.id;
+      this.todo.userId = this.$store.state.user.user.id;
       if (
         this.todoListSelected == 'Completed' ||
         this.todoListSelected == 'Todos'
       ) {
         this.$store.dispatch('submitTodo', this.todo);
       } else {
-        let list = this.$store.state.usersTodoLists.find(
+        let list = this.$store.state.todo.usersTodoLists.find(
           (list) => list.name == this.todoListSelected
         );
         this.todo.listId = list._id;
@@ -303,7 +310,7 @@ export default {
 
     //#region --List Methods--
     submitList() {
-      this.list.userId = this.$store.state.user.id;
+      this.list.userId = this.$store.state.user.user.id;
       this.$store.dispatch('submitList', this.list);
       this.list.name = '';
       this.showListInput = false;

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -24,11 +24,13 @@ export default new Vuex.Store({
       userCount: 0,
       userShowChange: true,
     },
-    todos: [],
-    completedTodos: [],
-    customListTodos: [],
-    customListTodosDontUse: [],
-    usersTodoLists: [],
+    todo: {
+      todos: [],
+      completedTodos: [],
+      customListTodos: [],
+      customListTodosDontUse: [],
+      usersTodoLists: [],
+    },
     newsWithPicture: [],
     newsNoPicture: [],
     finance: {
@@ -114,28 +116,28 @@ export default new Vuex.Store({
         }
       });
       // NOTE This method will recieve every single todo a user has, regardless of if it belongs to a custom list or not. However, in reality we only care about the todos without a listId property (the ones with a listId will be handled by the 'setCustomTodos' method), and so to ensure that the customTodosArray is not overwritten and filled with ALL custom todos I created essentialy a fake or dump array to store ALL custom todos.
-      state.todos = todoArr;
-      state.completedTodos = completedArr;
-      state.customListTodosDontUse = customListTodos;
+      state.todo.todos = todoArr;
+      state.todo.completedTodos = completedArr;
+      state.todo.customListTodosDontUse = customListTodos;
       // NOTE after updating a todo's completed property it will run this method. We want to check to see if any of the newly fetched custom todos are completed or not, if they are, remove them from the customListTodos array and insert it into the completedTodos array
-      state.customListTodosDontUse.forEach((t) => {
+      state.todo.customListTodosDontUse.forEach((t) => {
         if (t.completed == true) {
-          let todoIndexToRemove = state.customListTodos.findIndex(
+          let todoIndexToRemove = state.todo.customListTodos.findIndex(
             (todo) => todo._id == t._id
           );
-          state.customListTodos.splice(todoIndexToRemove, 1);
-          state.completedTodos.push(t);
+          state.todo.customListTodos.splice(todoIndexToRemove, 1);
+          state.todo.completedTodos.push(t);
         }
       });
     },
     setCustomTodos(state, todos) {
-      state.customListTodos = todos;
+      state.todo.customListTodos = todos;
     },
     //#endregion
 
     //#region --TodoList Methods--
     setTodoLists(state, todoLists) {
-      state.usersTodoLists = todoLists;
+      state.todo.usersTodoLists = todoLists;
     },
     //#endregion
 
@@ -337,7 +339,9 @@ export default new Vuex.Store({
     },
     async deleteCustomTodo({ dispatch }, todo) {
       await api.delete('todos/' + todo._id);
-      dispatch('getTodosByListId', todo.listId);
+      dispatch('getTodosByListId', todo.listId).then(() => {
+        dispatch('getTodosByUserId', todo.userId);
+      });
     },
     //#endregion
 


### PR DESCRIPTION
So I did the same thing in the store with Todos as I did with the finance and user variables, I moved them all into one parent 'todo{}' object. I've gone through the Todo component and it's actions/mutations in the store and reconfigured everything to account for the change.  Did some light testing and everything seems to be working properly. I even caught and fixed a bug where if you create a todo in a custom list, mark it complete, and then delete it; it would still be visible in the 'completedTodos' list, so I have adjusted the method responsible for deleting todos to 'refresh' both the custom lists and the regular lists when deleting a custom todo.  I also noticed that the Todo component had some places that accessed the user object in the store, so I had to reconfigure those places to reflect the changes to the user data in the store; so now I'm going to go through the rest of the app and make sure that if any other places need to access users or todos that it will relfect the changes I've made.