### PR TITLE
default view just needs minor css tweaks

### DIFF
--- a/client/src/components/SportsComponent.vue
+++ b/client/src/components/SportsComponent.vue
@@ -16,7 +16,7 @@
     <div class="defaultMainView" v-if="show.default">
       <div class="highlightedStory">
         <div class="highlighted">
-          <h3>{{ HighlightedNews.name }}</h3>
+          <h5>{{ HighlightedNews.name }}</h5>
           <img
             :src="HighlightedNews.image.thumbnail.contentUrl"
             alt="should be story image"
@@ -27,15 +27,31 @@
             }}</a>
           </p>
         </div>
+        <div class="otherHighlightedStories">
+          <div
+            class="otherHighlighted"
+            v-for="(other, index) in OtherHighlighted"
+            :key="index"
+            @click="switchHighlighted(other)"
+          >
+            <img
+              :src="other.image.thumbnail.contentUrl"
+              alt="should be image"
+            />
+            <p>{{ other.name }}</p>
+          </div>
+        </div>
       </div>
       <div class="otherStories">
         <div class="stories">
           <div class="story" v-for="(story, index) in SportsNews" :key="index">
-            <img
-              :src="story.image.thumbnail.contentUrl"
-              alt="should be image"
-            />
-            <p>{{ story.name }}</p>
+            <a :href="story.url" target="_blank">
+              <img
+                :src="story.image.thumbnail.contentUrl"
+                alt="should be image"
+              />
+              <p>{{ story.name }}</p></a
+            >
           </div>
         </div>
       </div>
@@ -93,6 +109,9 @@ export default {
     },
     HighlightedNews() {
       return this.$store.state.sports.highlightedNews;
+    },
+    OtherHighlighted() {
+      return this.$store.state.sports.otherHighlighted;
     },
   },
   methods: {
@@ -202,6 +221,9 @@ export default {
           break;
       }
     },
+    switchHighlighted(other) {
+      this.$store.dispatch('switchHighlighted', other);
+    },
   },
 };
 </script>
@@ -224,24 +246,70 @@ export default {
 .defaultMainView {
   display: flex;
 }
+/* Highlighted news section styling */
 .highlightedStory {
   width: 590px;
 }
+div.highlighted {
+  border-bottom: 1pt solid white;
+}
 div.highlighted img {
-  height: 200px;
-  width: 250px;
+  height: 125px;
+  width: 150px;
 }
 div.highlighted a {
-  font-size: 20px;
+  font-size: 16px;
   color: white;
 }
 div.highlighted a:hover {
   text-decoration-color: blue;
 }
+
+/* Other highlighted news section styling */
+.otherHighlightedStories {
+  display: flex;
+}
+div.otherHighlighted {
+  font-size: 12px;
+  text-align: center;
+  padding: 10px;
+}
+div.otherHighlighted:hover {
+  cursor: pointer;
+}
+div.otherHighlighted p {
+  margin-bottom: 0;
+  text-align: start;
+}
+
+/* Other news section styling */
 .otherStories {
   width: 290px;
   height: 440px;
   overflow-y: auto;
   padding-top: 10px;
+  border-left: 1pt solid white;
+}
+.story a {
+  display: flex;
+  font-size: 13px;
+  margin: 0px 0 0px 2px;
+  border-bottom: 1pt solid white;
+  color: white;
+}
+.story a:hover {
+  text-decoration-color: blue;
+}
+.story img {
+  height: 100px;
+  width: 100px;
+  padding: 5px 3px 5px 3px;
+}
+.story:hover {
+  box-shadow: 0pt 0pt 5pt white;
+}
+.story p {
+  align-self: center;
+  margin-bottom: 0;
 }
 </style>

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -51,6 +51,7 @@ export default new Vuex.Store({
     },
     sports: {
       highlightedNews: {},
+      otherHighlighted: [],
       news: [],
     },
   },
@@ -194,13 +195,28 @@ export default new Vuex.Store({
 
     //#region --Sports Methods--
     setSportsNews(state, sports) {
+      // Set the first highlightedNews object with first news article
       let first = sports.shift();
       state.sports.highlightedNews = first;
+      // Grab the next three articles and make them the otherHighlighted array
+      let nextThree = sports.slice(0, 3);
+      state.sports.otherHighlighted = nextThree;
+      sports.splice(0, 3);
+      // Set the rest
       state.sports.news = sports;
     },
     setMoreSportsNews(state, sports) {
       state.sports.news.push(sports);
       state.sports.news = state.sports.news.flat();
+    },
+    switchHighlighted(state, data) {
+      // Grab the current highlightedNews object and push it into otherHighlighted array
+      let oldHighlighted = state.sports.highlightedNews;
+      state.sports.otherHighlighted.push(oldHighlighted);
+      // Remove the highlighted news to be from the otherHighlighted array
+      state.sports.otherHighlighted.splice(data.index, 1);
+      // Set it as the new highlightedNews object
+      state.sports.highlightedNews = data.other;
     },
     //#endregion
   },
@@ -474,6 +490,12 @@ export default new Vuex.Store({
       commit('setSportsNews', firstBatch.data.value);
       let secondBatch = await api.get('sports/news/more');
       commit('setMoreSportsNews', secondBatch.data.value);
+    },
+    switchHighlighted({ commit, state }, other) {
+      debugger;
+      let indexToRemove = state.sports.otherHighlighted.indexOf(other);
+      let data = { other: other, index: indexToRemove };
+      commit('switchHighlighted', data);
     },
     //#endregion
   },


### PR DESCRIPTION
The core functionality of the default sports view is done, all data is properly rendered and you can successfully switch between the otherHighlighted news and current highlightedNews.  The only thing left now is to format the layout some more and polish it up a bit, then next is the individual leagues and seeing if I can create a universal league component to run all the different data through