### PR TITLE
upcoming/previous games per leageu

### DIFF
--- a/client/src/components/SportsComponent.vue
+++ b/client/src/components/SportsComponent.vue
@@ -137,7 +137,8 @@ export default {
             (this.show.mlb = false),
             (this.show.nhl = false),
             (this.show.mls = false),
-            (this.show.epl = false);
+            (this.show.epl = false),
+            this.$store.dispatch('getGames', 4391);
           break;
         case 'NCAAF':
           (this.show.default = false),
@@ -149,6 +150,7 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
+          this.$store.dispatch('getGames', 4479);
           break;
         case 'NBA':
           (this.show.nfl = false),
@@ -159,6 +161,7 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
+          this.$store.dispatch('getGames', 4387);
           break;
         case 'NCAAB':
           (this.show.default = false),
@@ -170,6 +173,7 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
+          this.$store.dispatch('getGames', 4607);
           break;
         case 'MLB':
           (this.show.default = false),
@@ -181,6 +185,7 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
+          this.$store.dispatch('getGames', 4424);
           break;
         case 'NHL':
           (this.show.default = false),
@@ -192,6 +197,7 @@ export default {
             (this.show.nhl = true),
             (this.show.mls = false),
             (this.show.epl = false);
+          this.$store.dispatch('getGames', 4380);
           break;
         case 'MLS':
           (this.show.default = false),
@@ -203,6 +209,7 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = true),
             (this.show.epl = false);
+          this.$store.dispatch('getGames', 4346);
           break;
         case 'EPL':
           (this.show.default = false),
@@ -214,6 +221,7 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = true);
+          this.$store.dispatch('getGames', 4328);
           break;
 
         default:

--- a/client/src/components/SportsLeagues.vue
+++ b/client/src/components/SportsLeagues.vue
@@ -1,7 +1,35 @@
 <template>
-  <div>
-    <h4>This is the tab where league data will be displayed.</h4>
-    <h5>{{ leagueData.name }}</h5>
+  <div class="leagueSection">
+    <div class="previousSection">
+      <div class="header">
+        <h5>Last Week's Games</h5>
+      </div>
+      <div class="listSection">
+        <div class="game" v-for="game in Previous" :key="game.idEvent">
+          <p>
+            {{ game.strHomeTeam }} {{ game.intHomeScore }} vs
+            {{ game.intAwayScore }} {{ game.strAwayTeam }}
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="leagueTableSection">
+      <div class="header">
+        <h5>{{ leagueData.name }}</h5>
+      </div>
+      <div class="tableSection"></div>
+    </div>
+    <div class="upcomingSection">
+      <div class="header">
+        <h5>Upcoming Games</h5>
+      </div>
+      <div class="listSection">
+        <div class="game" v-for="game in Upcoming" :key="game.idEvent">
+          <p class="time">{{ game.dateEvent }} @ {{ game.strTime }}</p>
+          <p>{{ game.strEvent }}</p>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -14,9 +42,47 @@ export default {
     return {};
   },
   mounted() {},
-  computed: {},
+  computed: {
+    Previous() {
+      return this.$store.state.sports.previous15;
+    },
+    Upcoming() {
+      return this.$store.state.sports.upcoming15;
+    },
+  },
   methods: {},
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.leagueSection {
+  display: flex;
+}
+.header {
+  text-align: center;
+}
+.header h5 {
+  /* position: relative; */
+  border-bottom: 2px solid white;
+}
+/* .header h5::after {
+  position: absolute;
+  content: '';
+  height: 2px;
+  width: 50%;
+  bottom: 0;
+  background: white;
+} */
+
+.previousSection {
+  width: 250px;
+}
+.listSection {
+  max-height: 405px;
+  overflow-y: auto;
+}
+.time {
+  font-size: 11px;
+  margin-bottom: 0;
+}
+</style>

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -53,6 +53,8 @@ export default new Vuex.Store({
       highlightedNews: {},
       otherHighlighted: [],
       news: [],
+      upcoming15: [],
+      previous15: [],
     },
   },
   mutations: {
@@ -217,6 +219,10 @@ export default new Vuex.Store({
       state.sports.otherHighlighted.splice(data.index, 1);
       // Set it as the new highlightedNews object
       state.sports.highlightedNews = data.other;
+    },
+    setGames(state, games) {
+      state.sports.upcoming15 = games.upcoming.data.events;
+      state.sports.previous15 = games.previous.data.events;
     },
     //#endregion
   },
@@ -492,10 +498,15 @@ export default new Vuex.Store({
       commit('setMoreSportsNews', secondBatch.data.value);
     },
     switchHighlighted({ commit, state }, other) {
-      debugger;
       let indexToRemove = state.sports.otherHighlighted.indexOf(other);
       let data = { other: other, index: indexToRemove };
       commit('switchHighlighted', data);
+    },
+    async getGames({ commit }, id) {
+      let games = {};
+      games.previous = await api.get('sports/games/previous/' + id);
+      games.upcoming = await api.get('sports/games/upcoming/' + id);
+      commit('setGames', games);
     },
     //#endregion
   },

--- a/server/controllers/SportsController.js
+++ b/server/controllers/SportsController.js
@@ -6,7 +6,9 @@ export class SportsController extends BaseController {
     super('api/sports');
     this.router
       .get('/news', this.getSportsNews)
-      .get('/news/more', this.getSportsNewsOffset);
+      .get('/news/more', this.getSportsNewsOffset)
+      .get('/games/previous/:id', this.getPreviousGames)
+      .get('/games/upcoming/:id', this.getUpcomingGames);
   }
 
   async getSportsNews(req, res, next) {
@@ -20,6 +22,22 @@ export class SportsController extends BaseController {
   async getSportsNewsOffset(req, res, next) {
     try {
       let data = await sportsService.getSportsNewsOffset();
+      return res.status(200).send(data.data);
+    } catch (error) {
+      next(error);
+    }
+  }
+  async getPreviousGames(req, res, next) {
+    try {
+      let data = await sportsService.getPreviousGames(req.params.id);
+      return res.status(200).send(data.data);
+    } catch (error) {
+      next(error);
+    }
+  }
+  async getUpcomingGames(req, res, next) {
+    try {
+      let data = await sportsService.getUpcomingGames(req.params.id);
       return res.status(200).send(data.data);
     } catch (error) {
       next(error);

--- a/server/services/SportsService.js
+++ b/server/services/SportsService.js
@@ -45,6 +45,33 @@ class SportsService {
       );
     }
   }
+  async getPreviousGames(id) {
+    console.log('league id', id);
+    try {
+      return await axios({
+        method: 'GET',
+        url: `https://www.thesportsdb.com/api/v1/json/1/eventspastleague.php?id=${id}`,
+      });
+    } catch (error) {
+      throw new ErrorResponse(
+        `Cant get previous games with that id:${id}.  ${error}`,
+        error.response.status
+      );
+    }
+  }
+  async getUpcomingGames(id) {
+    try {
+      return await axios({
+        method: 'GET',
+        url: `https://www.thesportsdb.com/api/v1/json/1/eventsnextleague.php?id=${id}`,
+      });
+    } catch (error) {
+      throw new ErrorResponse(
+        `Cant get upcoming games with that id:${id}.  ${error}`,
+        error.response.status
+      );
+    }
+  }
 }
 
 export const sportsService = new SportsService();


### PR DESCRIPTION
I'm working on the basic layout of the 'SportsLeagues.vue' component and so far I can properly select a league, and then render the name of the league and it's upcoming and previous games in the component.  The previous games have the scores while the upcoming games have the date and time. Next is to look do some minor formatting and then get the league tables.