### PR TITLE
can search news by category, can render on screen

### DIFF
--- a/client/src/components/NewsComponent.vue
+++ b/client/src/components/NewsComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="newsSection">
+  <!-- <div class="newsSection">
     <div class="input">
       <input
         type="text"
@@ -37,21 +37,80 @@
         </ul>
       </div>
     </div>
+  </div> -->
+  <div class="newsSection">
+    <div class="headerSection">
+      <div class="navbar">
+        <p @click="toggleNews('Home')">Home</p>
+        <p @click="toggleNews('US')">US</p>
+        <p @click="toggleNews('Politics')">Politics</p>
+        <p @click="toggleNews('World')">World</p>
+        <p @click="toggleNews('Science')">Science/Technology</p>
+        <p @click="toggleNews('Business')">Business</p>
+        <p @click="toggleNews('Entertainment')">Entertainment</p>
+        <p @click="toggleNews('Health')">Health</p>
+        <div class="input">
+          <input
+            type="text"
+            placeholder="New search"
+            v-model="news.query"
+            v-autowidth="{
+              maxWidth: '400px',
+              minWidth: '70px',
+              comfortZone: 20,
+            }"
+          />
+          <i class="fas fa-search" @click="submitNewsQuery"></i>
+        </div>
+      </div>
+    </div>
+    <div class="contentSection">
+      <div class="home" v-if="show.home">
+        <!-- this is where the 'trending' stories will go and act as the news component's 'home' page and will have slightly different layout -->
+        <h5>This is the home layout</h5>
+      </div>
+      <news-layout v-if="show.business" :newsData="business" />
+      <news-layout v-if="show.entertainment" :newsData="entertainment" />
+      <news-layout v-if="show.health" :newsData="health" />
+      <news-layout v-if="show.politics" :newsData="politics" />
+      <news-layout v-if="show.science" :newsData="science" />
+      <news-layout v-if="show.us" :newsData="us" />
+      <news-layout v-if="show.world" :newsData="world" />
+    </div>
   </div>
 </template>
 
 <script>
+import NewsLayout from '@/components/NewsComponentLayout.vue';
 import VueInputAutoWidth from 'vue-input-autowidth';
 import Vue from 'vue';
 Vue.use(VueInputAutoWidth);
 export default {
   name: 'NewsCompoenent',
+  components: { NewsLayout },
   data() {
     return {
       fetchedNewNews: false,
       news: {
         query: '',
       },
+      show: {
+        home: true,
+        business: false,
+        entertainment: false,
+        health: false,
+        politics: false,
+        science: false,
+        us: false,
+        world: false,
+      },
+      business: { name: 'Business' },
+      entertainment: { name: 'Entertainment' },
+      health: { name: 'Health' },
+      politics: { name: 'Politics' },
+      science: { name: 'Science/Technology' },
+      us: { name: 'United States' },
+      world: { name: 'World' },
     };
   },
   mounted() {
@@ -66,6 +125,101 @@ export default {
     },
   },
   methods: {
+    toggleNews(news) {
+      switch (news) {
+        case 'Home':
+          (this.show.home = true),
+            (this.show.business = false),
+            (this.show.entertainment = false),
+            (this.show.health = false),
+            (this.show.politics = false),
+            (this.show.science = false),
+            (this.show.us = false),
+            (this.show.world = false);
+          break;
+        case 'Business':
+          (this.show.home = false),
+            (this.show.business = true),
+            (this.show.entertainment = false),
+            (this.show.health = false),
+            (this.show.politics = false),
+            (this.show.science = false),
+            (this.show.us = false),
+            (this.show.world = false),
+            (this.show.epl = false);
+          this.$store.dispatch('getNewsCategory', 'Business');
+          break;
+        case 'Entertainment':
+          (this.show.home = false),
+            (this.show.business = false),
+            (this.show.entertainment = true),
+            (this.show.health = false),
+            (this.show.politics = false),
+            (this.show.science = false),
+            (this.show.us = false),
+            (this.show.world = false);
+          this.$store.dispatch('getNewsCategory', 'Entertainment');
+          break;
+        case 'Health':
+          (this.show.business = false),
+            (this.show.entertainment = false),
+            (this.show.health = true),
+            (this.show.politics = false),
+            (this.show.science = false),
+            (this.show.us = false),
+            (this.show.world = false);
+          this.$store.dispatch('getNewsCategory', 'Health');
+          break;
+        case 'Politics':
+          (this.show.home = false),
+            (this.show.business = false),
+            (this.show.entertainment = false),
+            (this.show.health = false),
+            (this.show.politics = true),
+            (this.show.science = false),
+            (this.show.us = false),
+            (this.show.world = false);
+          this.$store.dispatch('getNewsCategory', 'Politics');
+          break;
+        case 'Science':
+          (this.show.home = false),
+            (this.show.business = false),
+            (this.show.entertainment = false),
+            (this.show.health = false),
+            (this.show.politics = false),
+            (this.show.science = true),
+            (this.show.us = false),
+            (this.show.world = false);
+          this.$store.dispatch('getNewsCategory', 'Science');
+          break;
+        case 'US':
+          (this.show.home = false),
+            (this.show.business = false),
+            (this.show.entertainment = false),
+            (this.show.health = false),
+            (this.show.politics = false),
+            (this.show.science = false),
+            (this.show.us = true),
+            (this.show.world = false);
+          this.$store.dispatch('getNewsCategory', 'US');
+          break;
+        case 'World':
+          (this.show.home = false),
+            (this.show.business = false),
+            (this.show.entertainment = false),
+            (this.show.health = false),
+            (this.show.politics = false),
+            (this.show.science = false),
+            (this.show.us = false),
+            (this.show.world = true);
+          this.$store.dispatch('getNewsCategory', 'World');
+          break;
+
+        default:
+          console.log('That is not an option');
+          break;
+      }
+    },
     submitNewsQuery() {
       if (this.news.query !== '') {
         this.$store.dispatch('getNewNews', this.news);
@@ -86,6 +240,9 @@ export default {
   height: 500px;
   background-color: rgba(169, 169, 169, 0.596);
   color: white;
+}
+.navbar p:hover {
+  cursor: pointer;
 }
 .input {
   text-align: center;

--- a/client/src/components/NewsComponentLayout.vue
+++ b/client/src/components/NewsComponentLayout.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="storySection">
+    <h5>This is the {{ newsData.name }} component.</h5>
+    <div class="highlightedSection">
+      <div class="highlightedStories">
+        <p v-for="story in Highlighted" :key="story.name">{{ story.name }}</p>
+      </div>
+    </div>
+    <div class="otherSection">
+      <div class="otherStories"></div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'NewsLayout',
+  props: ['newsData'],
+  components: {},
+  data() {
+    return {};
+  },
+  mounted() {},
+  computed: {
+    Highlighted() {
+      return this.$store.state.news.category.highlighted;
+    },
+    Others() {
+      return this.$store.state.news.category.others;
+    },
+  },
+  methods: {},
+};
+</script>
+
+<style scoped></style>

--- a/client/src/components/NewsModal.vue
+++ b/client/src/components/NewsModal.vue
@@ -81,13 +81,13 @@ export default {
     };
   },
   mounted() {
-    // this.$store.dispatch('getNews');
+    // this.$store.dispatch('getNewsTrending');
     // this.$store.dispatch('getFinanceNews');
     // this.$store.dispatch('getWinnersLosers');
     // this.$store.dispatch('getUndervalued');
     // this.$store.dispatch('getTechnology');
     // this.$store.dispatch('getGrowers');
-    this.$store.dispatch('getSportsNews');
+    // this.$store.dispatch('getSportsNews');
   },
   computed: {},
   methods: {

--- a/client/src/components/SportsComponent.vue
+++ b/client/src/components/SportsComponent.vue
@@ -153,7 +153,8 @@ export default {
           this.$store.dispatch('getGames', 4479);
           break;
         case 'NBA':
-          (this.show.nfl = false),
+          (this.show.default = false),
+            (this.show.nfl = false),
             (this.show.ncaaf = false),
             (this.show.nba = true),
             (this.show.ncaab = false),

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -40,6 +40,15 @@ export default new Vuex.Store({
     news: {
       newsWithPicture: [],
       newsNoPicture: [],
+      category: {
+        highlighted: [],
+        others: [],
+      },
+      home: {
+        main: {},
+        justText: [],
+        others: [],
+      },
     },
     finance: {
       currentFinanceNews: [],
@@ -161,6 +170,19 @@ export default new Vuex.Store({
       state.news.newsWithPicture = news.slice(0, 20);
       state.news.newsNoPicture = news.slice(20);
     },
+    setNewsCategory(state, news) {
+      console.log('regular', news);
+      if (news.length == 12) {
+        state.news.category.highlighted = news.slice(0, 11);
+        state.news.category.others = [];
+      } else if (news.length > 12) {
+        state.news.category.highlighted = news.slice(0, 11);
+        state.news.category.others = news.slice(11);
+      }
+    },
+    // setNewsCategoryExtra(state, news) {
+    //   console.log('extra', news);
+    // },
     //#endregion
 
     //#region --Finance Methods--
@@ -407,9 +429,27 @@ export default new Vuex.Store({
     //#endregion
 
     //#region --News Methods--
-    async getNews({ commit }) {
-      let res = await api.get('news');
+    async getNewsTrending({ commit }) {
+      let res = await api.get('news/trending');
       commit('setNews', res.data.value);
+    },
+    async getNewsCategory({ commit }, category) {
+      // NOTE For some reason, the Bing News Search API isn't working properly and when using the 'category api', the optional parameters of 'count' and 'offset' only work for the category 'Health'; all other categories are uneffected by those parameters.  This means that I cannot get more than the first 12 stories for each category, besides 'Health'.  No matter how many times I make a call to the 'Politics' category, it will return the same 12 stories. This severly limits the amount of stories per category I can display, but there isn't much I can do about it now; in the future I may switch and migrate to a different API but for now this will work.
+      /** Code below is me trying to get multiple sets of results */
+      // if (category == 'Health') {
+      //   let res = await api.get('news/category/' + category);
+      //   commit('setNewsCategory', res.data);
+      // } else {
+      //   let first = await api.get('news/category/' + category);
+      //   let second = await api.get('news/category/v2/' + category);
+      //   let res = {
+      //     first: first.data.value,
+      //     second: second.data.value,
+      //   };
+      //   commit('setNewsCategoryExtra', res);
+      // }
+      let res = await api.get('news/category/' + category);
+      commit('setNewsCategory', res.data.value);
     },
     async getNewNews({ commit }, news) {
       let res = await api.post('news/change', news);

--- a/server/controllers/NewsController.js
+++ b/server/controllers/NewsController.js
@@ -4,17 +4,37 @@ import { newsService } from '../services/NewsService';
 export class NewsController extends BaseController {
   constructor() {
     super('api/news');
-    this.router.get('', this.getNews).post('/change', this.getNewNews);
+    this.router
+      .get('/trending', this.getNewsTrending)
+      .get('/category/:category', this.getNewsCategory)
+      // .get('/category/v2/:category', this.getNewsCategoryExtra)
+      .post('/change', this.getNewNews);
   }
 
-  async getNews(req, res, next) {
+  async getNewsTrending(req, res, next) {
     try {
-      let data = await newsService.getNews();
+      let data = await newsService.getNewsTrending();
       return res.status(200).send(data.data);
     } catch (error) {
       next(error);
     }
   }
+  async getNewsCategory(req, res, next) {
+    try {
+      let data = await newsService.getNewsCategory(req.params.category);
+      return res.status(200).send(data.data);
+    } catch (error) {
+      next(error);
+    }
+  }
+  // async getNewsCategoryExtra(req, res, next) {
+  //   try {
+  //     let data = await newsService.getNewsCategoryExtra(req.params.category);
+  //     return res.status(200).send(data.data);
+  //   } catch (error) {
+  //     next(error);
+  //   }
+  // }
   async getNewNews(req, res, next) {
     try {
       let data = await newsService.getNewNews(req.body);

--- a/server/services/NewsService.js
+++ b/server/services/NewsService.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import ErrorResponse from '../utils/ErrorResponse';
 
 class NewsService {
-  async getNews() {
+  async getNewsTrending() {
     try {
       return await axios({
         method: 'GET',
@@ -21,6 +21,55 @@ class NewsService {
       );
     }
   }
+  async getNewsCategory(category) {
+    try {
+      return await axios({
+        method: 'GET',
+        url: 'https://bing-news-search1.p.rapidapi.com/news',
+        params: {
+          count: 25,
+          safeSearch: 'Off',
+          category: category,
+          textFormat: 'Raw',
+        },
+        headers: {
+          'x-bingapis-sdk': 'true',
+          'x-rapidapi-key': process.env.X_RAPIDAPI_KEY,
+          'x-rapidapi-host': 'bing-news-search1.p.rapidapi.com',
+        },
+      });
+    } catch (error) {
+      throw new ErrorResponse(
+        `Cant get news stories.  ${error}`,
+        error.response.status
+      );
+    }
+  }
+  // async getNewsCategoryExtra(category) {
+  //   try {
+  //     return await axios({
+  //       method: 'GET',
+  //       url: 'https://bing-news-search1.p.rapidapi.com/news',
+  //       params: {
+  //         count: 12,
+  //         offset: 12,
+  //         safeSearch: 'Off',
+  //         category: category,
+  //         textFormat: 'Raw',
+  //       },
+  //       headers: {
+  //         'x-bingapis-sdk': 'true',
+  //         'x-rapidapi-key': process.env.X_RAPIDAPI_KEY,
+  //         'x-rapidapi-host': 'bing-news-search1.p.rapidapi.com',
+  //       },
+  //     });
+  //   } catch (error) {
+  //     throw new ErrorResponse(
+  //       `Cant get news stories.  ${error}`,
+  //       error.response.status
+  //     );
+  //   }
+  // }
   async getNewNews(query) {
     try {
       return await axios({


### PR DESCRIPTION
I am working on reconfiguring the news part of the news component to have 7 predetermined categories along with a search box.  However one thing that I've discovered and have put in notes in the store, is that the bing search api is working properly and some of the parameters for searches aren't being either read or executed; specifically the 'count' and 'offset' parameters, which is preventing me from getting more than the same default 12 top stories for each category EXCEPT 'Health' for some reason.  I may end up switching APIs later but for now this will work.  I can successfully search different categories and render the results on the screen. Next is to format the layout of the stories, then work on the 'home' page of the news section