### PR TITLE
got rid of stupid error messages when refresh

### DIFF
--- a/client/src/components/Quote.vue
+++ b/client/src/components/Quote.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="quote">
-    <p>{{ Quote.quote }}</p>
-    <p>Author: {{ Quote.author }}</p>
+    <p>{{ Quote.quote || 'Loading...' }}</p>
+    <p>Author: {{ Quote.author || 'Loading...' }}</p>
   </div>
 </template>
 

--- a/client/src/components/Weather.vue
+++ b/client/src/components/Weather.vue
@@ -39,7 +39,7 @@
             <p>Unkown Weather Condition</p>
           </div>
         </h1>
-        <h1 class="Temp">
+        <h1 class="Temp" v-if="gotWeather">
           {{ Math.round(Weather.main.temp) }}
           <span id="F">&#8457;</span>
         </h1>
@@ -80,6 +80,7 @@ export default {
   name: 'Weather',
   data() {
     return {
+      gotWeather: false,
       // To get weather
       coord: {
         lat: null,
@@ -129,6 +130,7 @@ export default {
       let coords = { ...this.coord };
       await this.$store.dispatch('getWeather', coords);
       this.checkCondition();
+      this.gotWeather = true;
     },
     error(err) {
       console.warn(`Error code: ${err.code}, ${err.message}.`);

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -16,10 +16,10 @@ export default new Vuex.Store({
       savedPhotos: [],
     },
     weather: {
-      weather: null,
+      weather: {},
     },
     quote: {
-      quote: null,
+      quote: {},
       savedQuotes: [],
     },
     user: {

--- a/client/src/views/Momentum.vue
+++ b/client/src/views/Momentum.vue
@@ -3,6 +3,7 @@
     class="momentum"
     id="backgroundImg"
     :style="{ 'background-image': 'url(' + Photo.urls.regular + ')' }"
+    v-if="gotPhoto"
   >
     <div class="container-fluid top">
       <div class="row justify-content-between">
@@ -124,10 +125,11 @@ export default {
       showTodosModal: false,
       showCalculator: false,
       showNewsModal: false,
+      gotPhoto: false,
     };
   },
   mounted() {
-    this.$store.dispatch('getPhoto');
+    this.getPhotoBackground();
   },
   computed: {
     Photo() {
@@ -135,6 +137,10 @@ export default {
     },
   },
   methods: {
+    async getPhotoBackground() {
+      await this.$store.dispatch('getPhoto');
+      this.gotPhoto = true;
+    },
     openPhotosModal() {
       this.showPhotoModal = true;
     },


### PR DESCRIPTION
I saw a post online about someone's component not rendering because at the time of render the data from an api hadn't arrived yet. This got me to thinking about the errors I got when my app first loaded due to some components not having the data at the exact time of rendering (thankfully Vue renders again when data is retrieved), however the errors were still annoying.  So, I don't know if this is bad practice or not but I just created some v-if's and some booleans and when the api call was made and a response gotten, then switch the boolean and then render the component. This all happens so quickly you don't even notice any difference in performance of the app, but now there are no errors everytime the page refreshes.