### PR TITLE
finished category layout component

### DIFF
--- a/client/src/components/NewsComponent.vue
+++ b/client/src/components/NewsComponent.vue
@@ -104,13 +104,13 @@ export default {
         us: false,
         world: false,
       },
-      business: { name: 'Business' },
-      entertainment: { name: 'Entertainment' },
-      health: { name: 'Health' },
-      politics: { name: 'Politics' },
-      science: { name: 'Science/Technology' },
-      us: { name: 'United States' },
-      world: { name: 'World' },
+      business: { name: 'Business', width: 155, margin: 237.5 },
+      entertainment: { name: 'Entertainment', width: 230, margin: 200 },
+      health: { name: 'Health', width: 120, margin: 255 },
+      politics: { name: 'Politics', width: 130, margin: 250 },
+      science: { name: 'Science/Technology', width: 320, margin: 155 },
+      us: { name: 'United States', width: 225, margin: 202.5 },
+      world: { name: 'World', width: 110, margin: 260 },
     };
   },
   mounted() {
@@ -240,6 +240,9 @@ export default {
   height: 500px;
   background-color: rgba(169, 169, 169, 0.596);
   color: white;
+}
+.navbar p {
+  margin-bottom: 0;
 }
 .navbar p:hover {
   cursor: pointer;

--- a/client/src/components/NewsComponentLayout.vue
+++ b/client/src/components/NewsComponentLayout.vue
@@ -1,13 +1,37 @@
 <template>
   <div class="storySection">
-    <h5>This is the {{ newsData.name }} component.</h5>
-    <div class="highlightedSection">
-      <div class="highlightedStories">
-        <p v-for="story in Highlighted" :key="story.name">{{ story.name }}</p>
+    <div class="content">
+      <div class="mainSection">
+        <h4
+          class="title"
+          :style="{ width: width + 'px', marginLeft: margin + 'px' }"
+        >
+          {{ newsData.name }}
+        </h4>
+        <div class="highlightedSection">
+          <div class="highlightedStories">
+            <div class="story" v-for="story in Highlighted" :key="story.name">
+              <h5>{{ story.name }}</h5>
+              <img :src="story.image.url" alt="should be an image" />
+              <a :href="story.webSearchUrl" target="_blank">
+                <p>{{ story.description }}</p></a
+              >
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="otherSection">
-      <div class="otherStories"></div>
+      <div class="otherSection">
+        <h5>Other Stories</h5>
+        <div class="otherStories">
+          <ul>
+            <li v-for="story in NoPicture" :key="story.name">
+              <a :href="story.webSearchUrl" target="_blank">
+                {{ story.name }}</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -18,19 +42,101 @@ export default {
   props: ['newsData'],
   components: {},
   data() {
-    return {};
+    return {
+      width: this.newsData.width,
+      margin: this.newsData.margin,
+    };
   },
   mounted() {},
+  beforeUpdate() {
+    this.width = this.newsData.width;
+    this.margin = this.newsData.margin;
+  },
   computed: {
     Highlighted() {
       return this.$store.state.news.category.highlighted;
     },
-    Others() {
-      return this.$store.state.news.category.others;
+    NoPicture() {
+      return this.$store.state.news.newsNoPicture;
     },
   },
   methods: {},
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.content {
+  display: flex;
+}
+h4.title {
+  text-align: center;
+  position: relative;
+  max-width: 315px;
+  margin-left: 157.5px;
+}
+h4.title::after {
+  position: absolute;
+  content: '';
+  width: 75%;
+  height: 2px;
+  left: 13%;
+  bottom: 0;
+  background: white;
+}
+.highlightedSection {
+  width: 630px;
+  max-height: 395px;
+  overflow-y: auto;
+}
+.story {
+  text-align: start;
+  border-top: 1pt solid white;
+  padding: 5px 5px 5px 10px;
+}
+.story img {
+  width: 150px;
+}
+.story p {
+  margin-bottom: 0;
+  color: whitesmoke;
+}
+.story p:hover {
+  text-shadow: 1pt 1pt 2pt grey;
+}
+
+/* Other Story section styling */
+.otherSection {
+  width: 225px;
+  max-height: 435px;
+}
+.otherSection h5 {
+  text-align: center;
+  position: relative;
+}
+.otherSection h5::after {
+  position: absolute;
+  content: '';
+  height: 1px;
+  width: 60%;
+  bottom: 0;
+  left: 20%;
+  background: white;
+}
+.otherStories {
+  max-height: 400px;
+  overflow-y: auto;
+}
+.otherStories ul {
+  padding-inline-start: 20px;
+}
+.otherStories li {
+  margin-bottom: 5px;
+}
+.otherStories a {
+  color: white;
+}
+.otherStories a:hover {
+  text-decoration-color: blue;
+  text-shadow: 1pt 1pt 2pt grey;
+}
+</style>

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -172,13 +172,7 @@ export default new Vuex.Store({
     },
     setNewsCategory(state, news) {
       console.log('regular', news);
-      if (news.length == 12) {
-        state.news.category.highlighted = news.slice(0, 11);
-        state.news.category.others = [];
-      } else if (news.length > 12) {
-        state.news.category.highlighted = news.slice(0, 11);
-        state.news.category.others = news.slice(11);
-      }
+      state.news.category.highlighted = news;
     },
     // setNewsCategoryExtra(state, news) {
     //   console.log('extra', news);
@@ -449,7 +443,23 @@ export default new Vuex.Store({
       //   commit('setNewsCategoryExtra', res);
       // }
       let res = await api.get('news/category/' + category);
-      commit('setNewsCategory', res.data.value);
+      // dispatch('checkForImage', res.data.value);
+      let customArr = [];
+      res.data.value.forEach((n) => {
+        if (Object.prototype.hasOwnProperty.call(n, 'image')) {
+          n.image.url = n.image.thumbnail.contentUrl;
+          n.webSearchUrl = n.url;
+          customArr.unshift(n);
+        } else {
+          n.image = {
+            url:
+              'https://www.conchovalleyhomepage.com/wp-content/uploads/sites/83/2020/05/BREAKING-NEWS-GENERIC-1.jpg?w=100&h=100&crop=1',
+          };
+          n.webSearchUrl = n.url;
+          customArr.push(n);
+        }
+      });
+      commit('setNewsCategory', customArr);
     },
     async getNewNews({ commit }, news) {
       let res = await api.post('news/change', news);
@@ -470,6 +480,29 @@ export default new Vuex.Store({
       });
       commit('setNews', customArr);
     },
+    // For whatever reason, whatever data gets passed into this function it is not getting read properly.  When you console log the argument getting passed in, it just shows this object that has 'commit, dispatch, getters, state, rootGetters/State' even though when you console log the parameter getting passed in and it is the right data. So somewhere between the dispatch and then the execution of this method, something happens to the data.  This means I'm going to have to rewrite the same code (WET).
+    // checkForImage(news) {
+    //   console.log('news', news);
+    //   console.log('hit the check');
+    //   let customArr = [];
+    //   news.forEach((n) => {
+    //     if (Object.prototype.hasOwnProperty.call(n, 'image')) {
+    //       n.image.url = n.image.thumbnail.contentUrl;
+    //       n.webSearchUrl = n.url;
+    //       customArr.unshift(n);
+    //       console.log('has own image');
+    //     } else {
+    //       n.image = {
+    //         url:
+    //           'https://www.conchovalleyhomepage.com/wp-content/uploads/sites/83/2020/05/BREAKING-NEWS-GENERIC-1.jpg?w=100&h=100&crop=1',
+    //       };
+    //       n.webSearchUrl = n.url;
+    //       customArr.push(n);
+    //       console.log('does not have own image');
+    //     }
+    //   });
+    //   return customArr;
+    // },
     //#endregion
 
     //#region --Finance Methods--

--- a/server/services/NewsService.js
+++ b/server/services/NewsService.js
@@ -27,7 +27,7 @@ class NewsService {
         method: 'GET',
         url: 'https://bing-news-search1.p.rapidapi.com/news',
         params: {
-          count: 25,
+          count: 12,
           safeSearch: 'Off',
           category: category,
           textFormat: 'Raw',


### PR DESCRIPTION
I have essentially finished the core functionality and layout of the 'NewsComponentLayout.vue' component; which is where the data for the 7 different news categories is displayed. The main stories are laid out on the left with name, img and desc; and then there are 'other' stories (news.newsNoPicture) which populate a list on the right that just has the story name.  Links work and take you to story source. Hardest part was conditionally styling the bottom border for the category name; i.e. 'Science/Technology' is much longer than 'World' and so the bottom border should also change according to the length of the title.  It's a minor feature but adds a lot to the UI.  Next step is to work on the 'Home' page of the news component; which I'm also thinking may act as the 'results' page for when a user searches for news, or I may make a separate 'hidden' page that only displays search results and is only shown when a user searches for something.  