### PR TITLE
basic sportsComponent mvp is done

### DIFF
--- a/client/src/components/NewsComponent.vue
+++ b/client/src/components/NewsComponent.vue
@@ -1,43 +1,4 @@
 <template>
-  <!-- <div class="newsSection">
-    <div class="input">
-      <input
-        type="text"
-        placeholder="New search"
-        v-model="news.query"
-        v-autowidth="{ maxWidth: '400px', minWidth: '70px', comfortZone: 20 }"
-      />
-      <i class="fas fa-search" @click="submitNewsQuery"></i>
-    </div>
-    <div class="content">
-      <div class="pictures">
-        <div
-          v-for="news in NewsWithPicture"
-          :key="news.name"
-          class="pictureContent"
-        >
-          <a :href="news.webSearchUrl" target="_blank">
-            <img
-              v-if="fetchedNewNews"
-              :src="news.image.url"
-              alt="No image available"
-            />
-            <img v-else :src="news.image.url" alt="No image available" />
-            <h5>{{ news.name }}</h5>
-          </a>
-        </div>
-      </div>
-      <div class="textContent">
-        <ul>
-          <li v-for="news in NewsNoPicture" :key="news.name">
-            <a :href="news.webSearchUrl" target="_blank"
-              ><p>{{ news.name }}</p></a
-            >
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div> -->
   <div class="newsSection">
     <div class="headerSection">
       <div class="navbar">
@@ -59,9 +20,9 @@
               minWidth: '70px',
               comfortZone: 20,
             }"
-            v-on:keyup.enter="submitNewsQuery"
+            v-on:keyup.enter="toggleNews('Search')"
           />
-          <i class="fas fa-search" @click="submitNewsQuery"></i>
+          <i class="fas fa-search" @click="toggleNews('Search')"></i>
         </div>
       </div>
     </div>
@@ -144,7 +105,6 @@ export default {
   components: { NewsLayout },
   data() {
     return {
-      newsCategory: 'Politics',
       news: {
         query: '',
         isSearch: true,
@@ -205,117 +165,124 @@ export default {
     },
   },
   methods: {
-    toggleNews(news) {
+    async toggleNews(news) {
       switch (news) {
         case 'Home':
-          (this.show.home = true),
-            (this.show.business = false),
-            (this.show.entertainment = false),
-            (this.show.health = false),
-            (this.show.politics = false),
-            (this.show.science = false),
-            (this.show.us = false),
-            (this.show.world = false),
-            (this.show.search = false);
+          this.show.home = true;
+          this.show.business = false;
+          this.show.entertainment = false;
+          this.show.health = false;
+          this.show.politics = false;
+          this.show.science = false;
+          this.show.us = false;
+          this.show.world = false;
+          this.show.search = false;
           this.$store.dispatch('getNewsTrending');
           break;
         case 'Business':
-          (this.show.home = false),
-            (this.show.business = true),
-            (this.show.entertainment = false),
-            (this.show.health = false),
-            (this.show.politics = false),
-            (this.show.science = false),
-            (this.show.us = false),
-            (this.show.world = false),
-            (this.show.search = false);
+          this.show.home = false;
+          this.show.business = true;
+          this.show.entertainment = false;
+          this.show.health = false;
+          this.show.politics = false;
+          this.show.science = false;
+          this.show.us = false;
+          this.show.world = false;
+          this.show.search = false;
           this.$store.dispatch('getNewsCategory', this.business);
           break;
         case 'Entertainment':
-          (this.show.home = false),
-            (this.show.business = false),
-            (this.show.entertainment = true),
-            (this.show.health = false),
-            (this.show.politics = false),
-            (this.show.science = false),
-            (this.show.us = false),
-            (this.show.world = false),
-            (this.show.search = false);
+          this.show.home = false;
+          this.show.business = false;
+          this.show.entertainment = true;
+          this.show.health = false;
+          this.show.politics = false;
+          this.show.science = false;
+          this.show.us = false;
+          this.show.world = false;
+          this.show.search = false;
           this.$store.dispatch('getNewsCategory', this.entertainment);
           break;
         case 'Health':
-          (this.show.business = false),
-            (this.show.entertainment = false),
-            (this.show.health = true),
-            (this.show.politics = false),
-            (this.show.science = false),
-            (this.show.us = false),
-            (this.show.world = false),
-            (this.show.search = false);
+          this.show.business = false;
+          this.show.entertainment = false;
+          this.show.health = true;
+          this.show.politics = false;
+          this.show.science = false;
+          this.show.us = false;
+          this.show.world = false;
+          this.show.search = false;
           this.$store.dispatch('getNewsCategory', this.health);
           break;
         case 'Politics':
-          (this.show.home = false),
-            (this.show.business = false),
-            (this.show.entertainment = false),
-            (this.show.health = false),
-            (this.show.politics = true),
-            (this.show.science = false),
-            (this.show.us = false),
-            (this.show.world = false),
-            (this.show.search = false);
+          this.show.home = false;
+          this.show.business = false;
+          this.show.entertainment = false;
+          this.show.health = false;
+          this.show.politics = true;
+          this.show.science = false;
+          this.show.us = false;
+          this.show.world = false;
+          this.show.search = false;
           this.$store.dispatch('getNewsCategory', this.politics);
           break;
         case 'Science':
-          (this.show.home = false),
-            (this.show.business = false),
-            (this.show.entertainment = false),
-            (this.show.health = false),
-            (this.show.politics = false),
-            (this.show.science = true),
-            (this.show.us = false),
-            (this.show.world = false),
-            (this.show.search = false);
+          this.show.home = false;
+          this.show.business = false;
+          this.show.entertainment = false;
+          this.show.health = false;
+          this.show.politics = false;
+          this.show.science = true;
+          this.show.us = false;
+          this.show.world = false;
+          this.show.search = false;
           this.$store.dispatch('getNewsCategory', this.science);
           break;
         case 'US':
-          (this.show.home = false),
-            (this.show.business = false),
-            (this.show.entertainment = false),
-            (this.show.health = false),
-            (this.show.politics = false),
-            (this.show.science = false),
-            (this.show.us = true),
-            (this.show.world = false),
-            (this.show.search = false);
+          this.show.home = false;
+          this.show.business = false;
+          this.show.entertainment = false;
+          this.show.health = false;
+          this.show.politics = false;
+          this.show.science = false;
+          this.show.us = true;
+          this.show.world = false;
+          this.show.search = false;
           this.$store.dispatch('getNewsCategory', this.us);
           break;
         case 'World':
-          (this.show.home = false),
-            (this.show.business = false),
-            (this.show.entertainment = false),
-            (this.show.health = false),
-            (this.show.politics = false),
-            (this.show.science = false),
-            (this.show.us = false),
-            (this.show.world = true),
-            (this.show.search = false);
+          this.show.home = false;
+          this.show.business = false;
+          this.show.entertainment = false;
+          this.show.health = false;
+          this.show.politics = false;
+          this.show.science = false;
+          this.show.us = false;
+          this.show.world = true;
+          this.show.search = false;
           this.$store.dispatch('getNewsCategory', this.world);
+          break;
+        case 'Search':
+          if (this.news.query !== '') {
+            await this.$store.dispatch('getNewNews', this.news);
+            this.show.search = true;
+            this.show.home = false;
+            this.show.business = false;
+            this.show.entertainment = false;
+            this.show.health = false;
+            this.show.politics = false;
+            this.show.science = false;
+            this.show.us = false;
+            this.show.world = false;
+            this.news.query = '';
+          } else {
+            this.news.query = '';
+          }
           break;
 
         default:
           console.log('That is not an option, check the category name.');
           break;
-      }
-    },
-    async submitNewsQuery() {
-      if (this.news.query !== '') {
-        await this.$store.dispatch('getNewNews', this.news);
-        this.show.home = false;
-        this.show.search = true;
-        this.news.query = '';
-      } else {
-        this.news.query = '';
       }
     },
   },

--- a/client/src/components/NewsModal.vue
+++ b/client/src/components/NewsModal.vue
@@ -91,14 +91,13 @@ export default {
     };
   },
   mounted() {
-    // this.$store.dispatch('getNewsTrending');
-    // this.$store.dispatch('getNewsCategory', this.newsHome);
-    // this.$store.dispatch('getFinanceNews');
-    // this.$store.dispatch('getWinnersLosers');
-    // this.$store.dispatch('getUndervalued');
-    // this.$store.dispatch('getTechnology');
-    // this.$store.dispatch('getGrowers');
-    this.$store.dispatch('getSportsNews');
+    this.$store.dispatch('getNewsTrending');
+    this.$store.dispatch('getNewsCategory', this.newsHome);
+    this.$store.dispatch('getFinanceNews');
+    this.$store.dispatch('getWinnersLosers');
+    this.$store.dispatch('getUndervalued');
+    this.$store.dispatch('getTechnology');
+    this.$store.dispatch('getGrowers');
   },
   computed: {},
   methods: {

--- a/client/src/components/SportsComponent.vue
+++ b/client/src/components/SportsComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sportsSection">
+  <div class="sportsSection" v-if="gotSports">
     <div class="headerSection">
       <div class="navbar">
         <p @click="toggleLeague('Home')">Home</p>
@@ -17,12 +17,9 @@
       <div class="highlightedStory">
         <div class="highlighted">
           <h5>{{ HighlightedNews.name }}</h5>
-          <img
-            :src="HighlightedNews.image.thumbnail.contentUrl"
-            alt="should be story image"
-          />
+          <img :src="HighlightedNews.image.url" alt="should be story image" />
           <p>
-            <a :href="HighlightedNews.url" target="_blank">{{
+            <a :href="HighlightedNews.webSearchUrl" target="_blank">{{
               HighlightedNews.description
             }}</a>
           </p>
@@ -34,10 +31,7 @@
             :key="index"
             @click="switchHighlighted(other)"
           >
-            <img
-              :src="other.image.thumbnail.contentUrl"
-              alt="should be image"
-            />
+            <img :src="other.image.url" alt="should be image" />
             <p>{{ other.name }}</p>
           </div>
         </div>
@@ -45,11 +39,8 @@
       <div class="otherStories">
         <div class="stories">
           <div class="story" v-for="(story, index) in SportsNews" :key="index">
-            <a :href="story.url" target="_blank">
-              <img
-                :src="story.image.thumbnail.contentUrl"
-                alt="should be image"
-              />
+            <a :href="story.webSearchUrl" target="_blank">
+              <img :src="story.image.url" alt="should be image" />
               <p>{{ story.name }}</p></a
             >
           </div>
@@ -65,7 +56,6 @@
       <sports-leagues v-if="show.nhl" :leagueData="nhl" />
       <sports-leagues v-if="show.mls" :leagueData="mls" />
       <sports-leagues v-if="show.epl" :leagueData="epl" />
-      <!-- This is where the (most likely) league component will go, where the league standing, and previous and upcoming 15 games will be displayed  -->
     </div>
   </div>
 </template>
@@ -79,6 +69,7 @@ export default {
   },
   data() {
     return {
+      gotSports: false,
       show: {
         default: true,
         nfl: false,
@@ -92,15 +83,56 @@ export default {
       },
       nfl: {
         name: 'National Football League',
+        topic: 'Sports_NFL',
+        isSports: true,
+        id: 4391,
       },
-      ncaaf: { name: 'National Collegiate Athletic Association Football' },
-      nba: { name: 'National Basketball Association' },
-      ncaab: { name: 'National Collegiate Athletic Association Basketball' },
-      mlb: { name: 'Major League Baseball' },
-      nhl: { name: 'National Hockey League' },
-      mls: { name: 'Major League Soccer' },
-      epl: { name: 'English Premier League' },
+      ncaaf: {
+        name: 'National Collegiate Athletic Association Football',
+        topic: 'Sports_CFB',
+        isSports: true,
+        id: 4479,
+      },
+      nba: {
+        name: 'National Basketball Association',
+        topic: 'Sports_NBA',
+        isSports: true,
+        id: 4387,
+      },
+      ncaab: {
+        name: 'National Collegiate Athletic Association Basketball',
+        topic: 'Sports_CBB',
+        isSports: true,
+        id: 4607,
+      },
+      mlb: {
+        name: 'Major League Baseball',
+        topic: 'Sports_MLB',
+        isSports: true,
+        id: 4424,
+      },
+      nhl: {
+        name: 'National Hockey League',
+        topic: 'Sports_NHL',
+        isSports: true,
+        id: 4380,
+      },
+      mls: {
+        name: 'Major League Soccer',
+        topic: 'Sports_Soccer',
+        isSports: true,
+        id: 4346,
+      },
+      epl: {
+        name: 'English Premier League',
+        topic: 'Sports_Soccer',
+        isSports: true,
+        id: 4328,
+      },
     };
+  },
+  beforeMount() {
+    this.getSportsNews();
   },
   mounted() {},
   computed: {
@@ -127,6 +159,7 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
+          this.$store.dispatch('getSportsNews', 'Sports');
           break;
         case 'NFL':
           (this.show.default = false),
@@ -138,7 +171,8 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false),
-            this.$store.dispatch('getGames', 4391);
+            this.$store.dispatch('getGames', this.nfl.id);
+          this.$store.dispatch('getNewsCategory', this.nfl);
           break;
         case 'NCAAF':
           (this.show.default = false),
@@ -150,7 +184,8 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
-          this.$store.dispatch('getGames', 4479);
+          this.$store.dispatch('getGames', this.ncaaf.id);
+          this.$store.dispatch('getNewsCategory', this.ncaaf);
           break;
         case 'NBA':
           (this.show.default = false),
@@ -162,7 +197,8 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
-          this.$store.dispatch('getGames', 4387);
+          this.$store.dispatch('getGames', this.nba.id);
+          this.$store.dispatch('getNewsCategory', this.nba);
           break;
         case 'NCAAB':
           (this.show.default = false),
@@ -174,7 +210,8 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
-          this.$store.dispatch('getGames', 4607);
+          this.$store.dispatch('getGames', this.ncaab.id);
+          this.$store.dispatch('getNewsCategory', this.ncaab);
           break;
         case 'MLB':
           (this.show.default = false),
@@ -186,7 +223,8 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = false);
-          this.$store.dispatch('getGames', 4424);
+          this.$store.dispatch('getGames', this.mlb.id);
+          this.$store.dispatch('getNewsCategory', this.mlb);
           break;
         case 'NHL':
           (this.show.default = false),
@@ -198,7 +236,8 @@ export default {
             (this.show.nhl = true),
             (this.show.mls = false),
             (this.show.epl = false);
-          this.$store.dispatch('getGames', 4380);
+          this.$store.dispatch('getGames', this.nhl.id);
+          this.$store.dispatch('getNewsCategory', this.nhl);
           break;
         case 'MLS':
           (this.show.default = false),
@@ -210,7 +249,8 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = true),
             (this.show.epl = false);
-          this.$store.dispatch('getGames', 4346);
+          this.$store.dispatch('getGames', this.mls.id);
+          this.$store.dispatch('getNewsCategory', this.mls);
           break;
         case 'EPL':
           (this.show.default = false),
@@ -222,13 +262,18 @@ export default {
             (this.show.nhl = false),
             (this.show.mls = false),
             (this.show.epl = true);
-          this.$store.dispatch('getGames', 4328);
+          this.$store.dispatch('getGames', this.epl.id);
+          this.$store.dispatch('getNewsCategory', this.epl);
           break;
 
         default:
           console.log('That is not an option');
           break;
       }
+    },
+    async getSportsNews() {
+      await this.$store.dispatch('getSportsNews', 'Sports');
+      this.gotSports = true;
     },
     switchHighlighted(other) {
       this.$store.dispatch('switchHighlighted', other);
@@ -272,6 +317,11 @@ div.highlighted a {
 }
 div.highlighted a:hover {
   text-decoration-color: blue;
+}
+div.highlighted p {
+  margin-bottom: 3px;
+  max-height: 95px;
+  overflow: hidden;
 }
 
 /* Other highlighted news section styling */

--- a/client/src/components/SportsLeagues.vue
+++ b/client/src/components/SportsLeagues.vue
@@ -2,32 +2,50 @@
   <div class="leagueSection">
     <div class="previousSection">
       <div class="header">
-        <h5>Last Week's Games</h5>
+        <h5>Previous Games</h5>
       </div>
       <div class="listSection">
         <div class="game" v-for="game in Previous" :key="game.idEvent">
           <p class="time">{{ game.dateEvent }} @ {{ game.strTime }}</p>
-          <p>
-            {{ game.strHomeTeam }} {{ game.intHomeScore }} vs
-            {{ game.intAwayScore }} {{ game.strAwayTeam }}
-          </p>
+          <div class="scores">
+            <p>{{ game.strHomeTeam }} {{ game.intHomeScore }}</p>
+            <p>vs</p>
+            <p>{{ game.strAwayTeam }} {{ game.intAwayScore }}</p>
+          </div>
         </div>
       </div>
     </div>
-    <div class="leagueTableSection">
+    <div class="leagueNewsSection">
       <div class="header">
         <h5>{{ leagueData.name }}</h5>
       </div>
-      <div class="tableSection"></div>
+      <div class="newsSection">
+        <div class="news" v-for="news in News" :key="news.name">
+          <img :src="news.image.url" alt="should be an image" />
+          <div class="text">
+            <a :href="news.webSearchUrl" target="_blank">
+              <h5>{{ news.name }}</h5>
+              <p>{{ news.description }}</p></a
+            >
+          </div>
+        </div>
+      </div>
     </div>
     <div class="upcomingSection">
       <div class="header">
         <h5>Upcoming Games</h5>
       </div>
       <div class="listSection">
-        <div class="game" v-for="game in Upcoming" :key="game.idEvent">
+        <div v-if="this.$store.state.sports.upcoming15 == null" class="noGames">
+          <p>No games scheduled currently, check back soon!</p>
+        </div>
+        <div v-else class="game" v-for="game in Upcoming" :key="game.idEvent">
           <p class="time">{{ game.dateEvent }} @ {{ game.strTime }}</p>
-          <p>{{ game.strEvent }}</p>
+          <div class="scores">
+            <p>{{ game.strHomeTeam }}</p>
+            <p>vs</p>
+            <p>{{ game.strAwayTeam }}</p>
+          </div>
         </div>
       </div>
     </div>
@@ -49,6 +67,9 @@ export default {
     },
     Upcoming() {
       return this.$store.state.sports.upcoming15;
+    },
+    News() {
+      return this.$store.state.sports.leagueNews;
     },
   },
   methods: {},
@@ -75,15 +96,63 @@ export default {
   background: white;
 } */
 
+p {
+  padding-left: 3px;
+}
+
+/* News section styling */
+.newsSection {
+  width: 475px;
+  max-height: 405px;
+  overflow-y: auto;
+}
+div.news {
+  display: flex;
+}
+div.news img {
+  height: 100px;
+  width: 100px;
+  padding-left: 5px;
+}
+div.text h5 {
+  font-size: 18px;
+  padding-left: 5px;
+}
+div.text p {
+  font-size: 14px;
+}
+div.text a {
+  color: white;
+}
+div.text a:hover {
+  text-decoration-color: blue;
+  text-shadow: 1pt 1pt 2pt grey;
+}
+
+/* Upcoming/Previous games styling */
 .previousSection {
-  width: 250px;
+  width: 200px;
+}
+.upcomingSection {
+  width: 180px;
 }
 .listSection {
   max-height: 405px;
   overflow-y: auto;
 }
+.game {
+  border: 1pt solid white;
+}
+.scores p {
+  margin-bottom: 0;
+  font-size: 14px;
+}
 .time {
   font-size: 11px;
   margin-bottom: 0;
+}
+.noGames {
+  text-align: center;
+  padding-top: 150px;
 }
 </style>

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -65,6 +65,7 @@ export default new Vuex.Store({
       highlightedNews: {},
       otherHighlighted: [],
       news: [],
+      leagueNews: [],
       upcoming15: [],
       previous15: [],
     },
@@ -234,9 +235,12 @@ export default new Vuex.Store({
       // Set the rest
       state.sports.news = sports;
     },
-    setMoreSportsNews(state, sports) {
-      state.sports.news.push(sports);
-      state.sports.news = state.sports.news.flat();
+    // setMoreSportsNews(state, sports) {
+    //   state.sports.news.push(sports);
+    //   state.sports.news = state.sports.news.flat();
+    // },
+    setNewsSports(state, news) {
+      state.sports.leagueNews = news;
     },
     switchHighlighted(state, data) {
       // Grab the current highlightedNews object and push it into otherHighlighted array
@@ -248,8 +252,8 @@ export default new Vuex.Store({
       state.sports.highlightedNews = data.other;
     },
     setGames(state, games) {
-      state.sports.upcoming15 = games.upcoming.data.events;
       state.sports.previous15 = games.previous.data.events;
+      state.sports.upcoming15 = games.upcoming.data.events;
     },
     //#endregion
   },
@@ -472,6 +476,8 @@ export default new Vuex.Store({
       });
       if (category.isNewsHome) {
         commit('setHomeNews', customArr);
+      } else if (category.isSports) {
+        commit('setNewsSports', customArr);
       } else {
         commit('setNewsCategory', customArr);
       }
@@ -583,11 +589,24 @@ export default new Vuex.Store({
     //#endregion
 
     //#region --Sports Methods--
-    async getSportsNews({ commit }) {
-      let firstBatch = await api.get('sports/news');
-      commit('setSportsNews', firstBatch.data.value);
-      let secondBatch = await api.get('sports/news/more');
-      commit('setMoreSportsNews', secondBatch.data.value);
+    async getSportsNews({ commit }, topic) {
+      let data = await api.get('sports/news/' + topic);
+      let customArr = [];
+      data.data.value.forEach((n) => {
+        if (Object.prototype.hasOwnProperty.call(n, 'image')) {
+          n.image.url = n.image.thumbnail.contentUrl;
+          n.webSearchUrl = n.url;
+          customArr.unshift(n);
+        } else {
+          n.image = {
+            url:
+              'https://www.conchovalleyhomepage.com/wp-content/uploads/sites/83/2020/05/BREAKING-NEWS-GENERIC-1.jpg?w=100&h=100&crop=1',
+          };
+          n.webSearchUrl = n.url;
+          customArr.push(n);
+        }
+      });
+      commit('setSportsNews', customArr);
     },
     switchHighlighted({ commit, state }, other) {
       let indexToRemove = state.sports.otherHighlighted.indexOf(other);

--- a/server/controllers/SportsController.js
+++ b/server/controllers/SportsController.js
@@ -5,7 +5,7 @@ export class SportsController extends BaseController {
   constructor() {
     super('api/sports');
     this.router
-      .get('/news', this.getSportsNews)
+      .get('/news/:topic', this.getSportsNews)
       .get('/news/more', this.getSportsNewsOffset)
       .get('/games/previous/:id', this.getPreviousGames)
       .get('/games/upcoming/:id', this.getUpcomingGames);
@@ -13,7 +13,7 @@ export class SportsController extends BaseController {
 
   async getSportsNews(req, res, next) {
     try {
-      let data = await sportsService.getSportsNews();
+      let data = await sportsService.getSportsNews(req.params.topic);
       return res.status(200).send(data.data);
     } catch (error) {
       next(error);

--- a/server/services/SportsService.js
+++ b/server/services/SportsService.js
@@ -2,12 +2,18 @@ import axios from 'axios';
 import ErrorResponse from '../utils/ErrorResponse';
 
 class SportsService {
-  async getSportsNews() {
+  async getSportsNews(topic) {
     try {
       return await axios({
         method: 'GET',
-        url: 'https://bing-news-search1.p.rapidapi.com/news',
-        params: { safeSearch: 'Off', category: 'sports', textFormat: 'Raw' },
+        url: 'https://bing-news-search1.p.rapidapi.com/news/search',
+        params: {
+          q: topic,
+          freshness: 'Month',
+          textFormat: 'Raw',
+          safeSearch: 'Off',
+          count: 40,
+        },
         headers: {
           'x-bingapis-sdk': 'true',
           'x-rapidapi-key': process.env.X_RAPIDAPI_KEY,
@@ -16,7 +22,7 @@ class SportsService {
       });
     } catch (error) {
       throw new ErrorResponse(
-        `Cant get sports stories.  ${error}`,
+        `Cant get sports news for that topic, '${query}'. ${error}`,
         error.response.status
       );
     }


### PR DESCRIPTION
So instead of displaying a league table in the middle of the 'SportsComponentLayout' component, I decided to just display relevant news for that particular sport/league.  The data for the league table from the SportsDB api isn't that reliable in terms of total games played and some leagues' data for the 2019-2020 season is missing. So instead I'm just using the Bing Search api to go get the relevant news.  If there are no upcoming games, a message will display instead. The basic functionality of the sports section of the news component is complete.  In the future, regarding the entire news component, I may want to add in some extra features/more detail. For example, in the finance section, if a user clicks on a particular stock some more basic and detailed information will be presented for that particular stock; same goes for a sports team. However, now that the mvp is done I'm going to move onto the Contacts/Calendar components.