### PR TITLE
conditionally toggle news/calc based on user pref

### DIFF
--- a/client/src/components/Greeting.vue
+++ b/client/src/components/Greeting.vue
@@ -102,6 +102,8 @@ export default {
       user: {
         name: '',
         militaryTimeSelected: false,
+        calculatorSelected: false,
+        newsSelected: false,
         createdTodoLists: [],
       },
     };

--- a/client/src/components/Settings.vue
+++ b/client/src/components/Settings.vue
@@ -48,6 +48,7 @@
         </ul>
       </li>
       <li @click="toggleCalculator">Toggle Calculator</li>
+      <li @click="toggleNews">Toggle News</li>
     </ul>
   </div>
   <!--  NOTE This was the original modal, however the way it was setup meant you had to click the button to open AND close the modal, you couldn't click on the screen and have it disappear. However, I liked that when you selected 'Get Photo/Quote' or 'Save Photo/Quote' and the time options, it didn't close; as this allowed the user to quickly get new photos or quotes without having to navigate back to those buttons everytime. So I guess this would come down to user preference. I'm leaving it here to be able to change if needed; both are fully functional.
@@ -141,7 +142,8 @@ export default {
           regular: this.$store.state.photo.photo.urls.regular,
           thumbUrl: this.$store.state.photo.photo.urls.thumb,
         },
-        downloadLocation: this.$store.state.photo.photo.links.download_location,
+        download_location: this.$store.state.photo.photo.links
+          .download_location,
         userName: this.$store.state.photo.photo.user.username,
         name: this.$store.state.photo.photo.user.name,
         unsplashLink: this.$store.state.photo.photo.links.html,
@@ -189,6 +191,25 @@ export default {
     //#region --Calculator Methods--
     toggleCalculator() {
       this.$emit('toggleCalculator');
+      let user = this.$store.state.user.user;
+      if (user.calculatorSelected == true) {
+        this.$store.state.user.user.calculatorSelected = false;
+      } else {
+        this.$store.state.user.user.calculatorSelected = true;
+      }
+      this.$store.dispatch('updateUserById', this.$store.state.user.user);
+    },
+    //#endregion
+    //#region --News Methods--
+    toggleNews() {
+      this.$emit('toggleNews');
+      let user = this.$store.state.user.user;
+      if (user.newsSelected == true) {
+        this.$store.state.user.user.newsSelected = false;
+      } else {
+        this.$store.state.user.user.newsSelected = true;
+      }
+      this.$store.dispatch('updateUserById', this.$store.state.user.user);
     },
     //#endregion
   },

--- a/client/src/views/Momentum.vue
+++ b/client/src/views/Momentum.vue
@@ -12,10 +12,11 @@
             @openPhotosModal="openPhotosModal"
             @openQuotesModal="openQuotesModal"
             @toggleCalculator="toggleCalculator"
+            @toggleNews="toggleNews"
           />
         </div>
         <div class="col-3 offset-8 d-flex">
-          <div class="toggleNews" @click="openNewsModal">
+          <div v-if="toggledNews" class="toggleNews" @click="openNewsModal">
             <i class="far fa-newspaper fa-2x"></i>
             <p>NEWS</p>
           </div>
@@ -40,7 +41,7 @@
         <news-modal v-if="showNewsModal" @close-news-modal="closeNewsModal" />
         <div class="col-3">
           <!-- <calculator /> -->
-          <calculator v-if="showCalculator" class="calculator" />
+          <calculator v-if="toggledCalculator" class="calculator" />
         </div>
         <!-- NOTE Can't use bootstrap modal because for some reason I get an error saying the '$' symbol when trying to programatically open/close it using bootstrap's $('#myModal').modal(options) is 'undefined'. I have tried using a cdn directly from jquery, I have tried npm i-ing jquery directly into the project and neither work.  I have tried reordering the cdns, I have tried nmp i-ing bootstrap directly, and neither work.  I have no idea why it's not working. So the workaround is to use a modal made by the vue devs found at https://vuejs.org/v2/examples/modal.html?
           <div
@@ -137,7 +138,9 @@ export default {
       showPhotoModal: false,
       showQuoteModal: false,
       showTodosModal: false,
+      toggledCalculator: false,
       showCalculator: false,
+      toggledNews: false,
       showNewsModal: false,
       showUtilities: false,
       gotPhoto: false,
@@ -145,6 +148,14 @@ export default {
   },
   mounted() {
     this.getPhotoBackground();
+    this.$root.$on('checkLastUser', (result) => {
+      this.checkCaclulator(result);
+      this.checkNews(result);
+    });
+    this.$root.$on('changedUser', (newUser) => {
+      this.checkCaclulator(newUser);
+      this.checkNews(newUser);
+    });
   },
   computed: {
     Photo() {
@@ -171,11 +182,25 @@ export default {
       this.showQuoteModal = false;
     },
     // News Modal control
+    toggleNews() {
+      if (this.toggledNews == true) {
+        this.toggledNews = false;
+      } else if (this.toggledNews == false) {
+        this.toggledNews = true;
+      }
+    },
     openNewsModal() {
       this.showNewsModal = true;
     },
     closeNewsModal() {
       this.showNewsModal = false;
+    },
+    checkNews(user) {
+      if (user.newsSelected == true) {
+        this.toggledNews = true;
+      } else {
+        this.toggledNews = false;
+      }
     },
     // Todos Control
     toggleTodos() {
@@ -187,10 +212,17 @@ export default {
     },
     // Calculator control
     toggleCalculator() {
-      if (this.showCalculator == false) {
-        this.showCalculator = true;
+      if (this.toggledCalculator == false) {
+        this.toggledCalculator = true;
       } else {
-        this.showCalculator = false;
+        this.toggledCalculator = false;
+      }
+    },
+    checkCaclulator(user) {
+      if (user.calculatorSelected == true) {
+        this.toggledCalculator = true;
+      } else {
+        this.toggledCalculator = false;
       }
     },
     // Utilities control

--- a/server/models/LastUser.js
+++ b/server/models/LastUser.js
@@ -5,6 +5,9 @@ const LastUser = new Schema(
   {
     name: { type: String, required: true },
     militaryTimeSelected: { type: Boolean, required: true },
+    calculatorSelected: { type: Boolean, required: true },
+    newsSelected: { type: Boolean, required: true },
+    createdTodoLists: { type: Array, required: true },
   },
   { timestamps: true, toJSON: { virtuals: true } }
 );

--- a/server/models/Photo.js
+++ b/server/models/Photo.js
@@ -12,7 +12,7 @@ const Photo = new Schema(
       regular: { type: String, required: true },
       thumbUrl: { type: String, required: true },
     },
-    downloadLocation: { type: String, required: true },
+    download_location: { type: String, required: true },
     userName: { type: String, required: true },
     name: { type: String, required: true },
     unsplashLink: { type: String, required: true },

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -13,6 +13,8 @@ const UserSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
     militaryTimeSelected: { type: Boolean, required: true },
+    calculatorSelected: { type: Boolean, required: true },
+    newsSelected: { type: Boolean, required: true },
     createdTodoLists: { type: Array, required: true },
   },
   { timestamps: true, toJSON: { virtuals: true } }

--- a/server/services/UserService.js
+++ b/server/services/UserService.js
@@ -36,7 +36,9 @@ class UserService {
   }
   async updateUserById(user) {
     try {
-      return await User.findByIdAndUpdate(user.id, user);
+      await User.findByIdAndUpdate(user.id, user);
+      let updated = User.findById(user.id);
+      return updated;
       // return await dbContext.User.findByIdAndUpdate(user.id, user);
     } catch (error) {
       throw new ErrorResponse(


### PR DESCRIPTION
Now when a specific user toggles the calculator or the news components, that choice will be stored on the user object.  So the next time they 'log in' the app will conditionally render those components or not, based on the user's preference.  So now users have three choices, military vs standard time, whether to show the calculator or not and whether to show the news or not.  This allows for user flexibility, some may want a minimal UI and display while others may not mind a little more 'cluttered' screen in exchange for more features; now they have control.  