### PR TITLE
Reposition weather elements

### DIFF
--- a/client/src/components/Clock.vue
+++ b/client/src/components/Clock.vue
@@ -81,7 +81,7 @@ export default {
 
 <style scoped>
 .clock {
-  font-size: 10rem;
+  font-size: 11rem;
   color: white;
   text-align: center;
   text-shadow: 3px 3px 5px black;

--- a/client/src/components/Greeting.vue
+++ b/client/src/components/Greeting.vue
@@ -205,6 +205,7 @@ export default {
 }
 h1 {
   text-shadow: 3px 3px 5px black;
+  font-size: 64px;
 }
 input {
   border: none;

--- a/client/src/components/Quote.vue
+++ b/client/src/components/Quote.vue
@@ -46,7 +46,7 @@ export default {
 p {
   font-size: 20px;
   color: white;
-  text-shadow: 3px 3px 5px black;
+  text-shadow: 3px 3px 3px black;
   margin-bottom: 0;
 }
 /* Quote transition styling */

--- a/client/src/components/Settings.vue
+++ b/client/src/components/Settings.vue
@@ -233,14 +233,14 @@ export default {
 p {
   color: rgb(255, 255, 255);
   font-size: 1.3rem;
-  text-shadow: 1px 1px 1px rgb(0, 0, 0);
+  text-shadow: 2px 2px 3px rgb(0, 0, 0);
   margin-top: 10px;
 }
 p:hover {
   color: white;
   cursor: pointer;
   font-size: 1.4rem;
-  text-shadow: 2px 2px 2px black;
+  text-shadow: 4px 4px 3px black;
 }
 
 li {

--- a/client/src/components/Utilities/Utilities.vue
+++ b/client/src/components/Utilities/Utilities.vue
@@ -78,8 +78,8 @@ export default {
 .utilitiesComponent {
   background-color: rgba(245, 245, 245, 0.815);
   border: 1pt solid black;
-  width: 575px;
-  height: 450px;
+  width: 500px;
+  height: 415px;
   position: absolute;
   z-index: 5;
   bottom: 70px;

--- a/client/src/components/Weather.vue
+++ b/client/src/components/Weather.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <!-- <div
     v-if="showWeatherColor"
     class="main ml-auto"
     id="changeColor"
@@ -7,7 +7,29 @@
   >
     <div class="background">
       <div class="content">
-        <h1 class="Time">{{ month }} {{ day }}</h1>
+        <div class="TimeLocation">
+          <h1 class="Time">{{ month }} {{ day }}</h1>
+          <p>/</p>
+          <div>
+            <input
+              v-on:blur="onClickOutside"
+              ref="focus"
+              type="text"
+              v-model="city.name"
+              v-on:keyup.enter="submitNewCity"
+              v-autowidth="{
+                maxWidth: '100px',
+                minWidth: '20px',
+                comfortZone: 10,
+              }"
+              v-if="city.changeCity"
+              class="locationInput"
+            />
+            <h1 class="Location" v-else @click="getNewCity">
+              {{ Weather.name }}
+            </h1>
+          </div>
+        </div>
         <h1 class="Temp" v-if="gotWeather">
           {{ Math.round(Weather.main.temp) }}
           <p id="F"><small>&#176;</small></p>
@@ -43,36 +65,15 @@
             <p>Unkown Weather Condition</p>
           </div>
         </h1>
-        <div>
-          <input
-            v-on:blur="onClickOutside"
-            ref="focus"
-            type="text"
-            v-model="city.name"
-            v-on:keyup.enter="submitNewCity"
-            v-autowidth="{
-              maxWidth: '100px',
-              minWidth: '20px',
-              comfortZone: 10,
-            }"
-            v-if="city.changeCity"
-            class="locationInput"
-          />
-          <h1 class="Location" v-else @click="getNewCity">
-            <i
-              class="fas fa-map-marker-alt locationIcon"
-              :style="{ color: locationIconColor }"
-            ></i>
-            {{ Weather.name }}
-          </h1>
-        </div>
       </div>
     </div>
-  </div>
-  <div v-else class="main ml-auto" id="changeColor">
+  </div> -->
+  <div class="main ml-auto" id="changeColor">
     <div class="background">
       <div class="content">
-        <h1 class="Time">{{ month }} {{ day }}</h1>
+        <div class="TimeLocation">
+          <h1 class="Time">{{ month }} {{ day }} / {{ Weather.name }}</h1>
+        </div>
         <h1 class="Temp" v-if="gotWeather">
           {{ Math.round(Weather.main.temp) }}
           <p id="F"><small>&#176;</small></p>
@@ -80,52 +81,26 @@
         <h1 class="Condition">
           <div v-if="sunny">
             <i class="fas fa-sun icon"></i>
-            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="rain">
             <i class="fas fa-cloud-showers-heavy icon"></i>
-            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="cloudy">
             <i class="fas fa-cloud icon"></i>
-            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="snow">
             <i class="far fa-snowflake icon"></i>
-            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="fog">
             <i class="fas fa-smog icon"></i>
-            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="mist">
             <i class="fas fa-smog icon"></i>
-            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else>
             <i class="fas fa-question icon"></i>
-            <p>Unkown Weather Condition</p>
           </div>
         </h1>
-        <div>
-          <input
-            v-on:blur="onClickOutside"
-            ref="focus"
-            type="text"
-            v-model="city.name"
-            v-on:keyup.enter="submitNewCity"
-            v-autowidth="{
-              maxWidth: '100px',
-              minWidth: '20px',
-              comfortZone: 10,
-            }"
-            v-if="city.changeCity"
-            class="locationInput"
-          />
-          <h1 class="Location" v-else @click="getNewCity">
-            {{ Weather.name }}
-          </h1>
-        </div>
       </div>
     </div>
   </div>
@@ -172,15 +147,6 @@ export default {
   mounted() {
     this.getLocation();
     this.getDate();
-    this.$root.$on('revealWeather', () => {
-      this.setBackgroundColor();
-      this.showWeatherColor = true;
-      console.log('true', this.showWeatherColor);
-    });
-    this.$root.$on('hideWeather', () => {
-      this.showWeatherColor = false;
-      console.log('false', this.showWeatherColor);
-    });
   },
   computed: {
     Weather() {
@@ -397,8 +363,6 @@ export default {
         this.iconColor = 'black';
         this.locationIconColor = 'black';
       }
-      console.log('icon color', this.iconColor);
-      console.log('locaiton color', this.locationIconColor);
     },
     onClickOutside() {
       this.city.changeCity = false;
@@ -415,19 +379,18 @@ export default {
   position: relative;
   margin-top: 15px;
   height: 90px;
-  width: 135px;
+  width: 170px;
   border-radius: 10px;
   /* box-shadow: 2px 2px 1px rgba(0, 0, 0, 0.2); */
   background-color: transparent;
   color: white;
+  text-shadow: 1pt 1pt 3pt black;
+}
+.main:hover {
+  cursor: pointer;
 }
 
 /* Widget styling */
-
-.icon {
-  z-index: 1000;
-  font-size: 27px !important;
-}
 .Condition {
   z-index: 1000;
   position: absolute;
@@ -438,10 +401,9 @@ export default {
   top: 22px;
   text-align: center;
 }
-.Condition p {
-  margin-bottom: 0;
-  font-size: 11px;
-  margin-top: 0;
+.icon {
+  z-index: 1000;
+  font-size: 35px !important;
 }
 
 .Temp {
@@ -450,11 +412,10 @@ export default {
   font-family: 'Roboto', sans-serif;
   font-size: 45px;
   font-weight: 400;
-  right: 60px;
+  right: 70px;
   bottom: 10px;
   display: flex;
 }
-
 #F {
   z-index: 1000;
   font-family: 'Roboto', sans-serif;
@@ -462,38 +423,21 @@ export default {
   font-size: 30px;
 }
 
-.Time {
+.TimeLocation {
   z-index: 1000;
   position: absolute;
-  font-family: 'Noto Sans', sans-serif;
+  right: 20px;
+  top: 0px;
+  display: flex;
+}
+.TimeLocation h1 {
   font-size: 12px;
-  font-weight: 100;
-  right: 20px;
-  bottom: 62px;
-}
-
-.locationIcon {
-  z-index: 1000;
-  font-size: 10px;
-  color: white;
-}
-
-.Location {
-  z-index: 1000;
-  position: absolute;
-  font-family: 'Noto Sans', sans-serif;
-  font-size: 14px;
   font-weight: 200;
-  right: 20px;
-  bottom: 0px;
-  cursor: pointer;
+  font-family: 'Noto Sans', sans-serif;
+  margin-bottom: 0;
+  text-shadow: 1pt 1pt 2pt black !important;
 }
-.locationInput {
-  z-index: 1000;
-  position: absolute;
-  right: 20px;
-  bottom: 5px;
-}
+
 @media (max-width: 1024px) {
   .main {
     width: 225px;

--- a/client/src/components/Weather.vue
+++ b/client/src/components/Weather.vue
@@ -7,44 +7,42 @@
   >
     <div class="background">
       <div class="content">
+        <h1 class="Time">{{ month }} {{ day }}</h1>
+        <h1 class="Temp" v-if="gotWeather">
+          {{ Math.round(Weather.main.temp) }}
+          <p id="F"><small>&#176;</small></p>
+        </h1>
         <h1 class="Condition">
           <div v-if="sunny">
             <i class="fas fa-sun icon" :style="{ color: iconColor }"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="rain">
-            <i
-              class="fas fa-cloud-showers-heavy icon"
-              :style="{ color: iconColor }"
-            ></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
+            <i class="fas fa-cloud-showers-heavy icon"></i>
+            :style="{ color: iconColor }"
           </div>
           <div v-else-if="cloudy">
             <i class="fas fa-cloud icon" :style="{ color: iconColor }"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="snow">
             <i class="far fa-snowflake icon" :style="{ color: iconColor }"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="fog">
             <i class="fas fa-smog icon" :style="{ color: iconColor }"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="mist">
             <i class="fas fa-smog icon" :style="{ color: iconColor }"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else>
             <i class="fas fa-question icon" :style="{ color: iconColor }"></i>
             <p>Unkown Weather Condition</p>
           </div>
         </h1>
-        <h1 class="Temp" v-if="gotWeather">
-          {{ Math.round(Weather.main.temp) }}
-          <span id="F">&#8457;</span>
-        </h1>
-        <h1 class="Time">{{ month }} {{ day }}</h1>
         <div>
           <input
             v-on:blur="onClickOutside"
@@ -74,41 +72,41 @@
   <div v-else class="main ml-auto" id="changeColor">
     <div class="background">
       <div class="content">
+        <h1 class="Time">{{ month }} {{ day }}</h1>
+        <h1 class="Temp" v-if="gotWeather">
+          {{ Math.round(Weather.main.temp) }}
+          <p id="F"><small>&#176;</small></p>
+        </h1>
         <h1 class="Condition">
           <div v-if="sunny">
             <i class="fas fa-sun icon"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="rain">
             <i class="fas fa-cloud-showers-heavy icon"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="cloudy">
             <i class="fas fa-cloud icon"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="snow">
             <i class="far fa-snowflake icon"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="fog">
             <i class="fas fa-smog icon"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else-if="mist">
             <i class="fas fa-smog icon"></i>
-            {{ Weather.weather[0].main }}
+            <p>{{ Weather.weather[0].main }}</p>
           </div>
           <div v-else>
             <i class="fas fa-question icon"></i>
             <p>Unkown Weather Condition</p>
           </div>
         </h1>
-        <h1 class="Temp" v-if="gotWeather">
-          {{ Math.round(Weather.main.temp) }}
-          <span id="F">&#8457;</span>
-        </h1>
-        <h1 class="Time">{{ month }} {{ day }}</h1>
         <div>
           <input
             v-on:blur="onClickOutside"
@@ -125,7 +123,6 @@
             class="locationInput"
           />
           <h1 class="Location" v-else @click="getNewCity">
-            <i class="fas fa-map-marker-alt locationIcon"></i>
             {{ Weather.name }}
           </h1>
         </div>
@@ -418,7 +415,7 @@ export default {
   position: relative;
   margin-top: 15px;
   height: 90px;
-  width: 230px;
+  width: 135px;
   border-radius: 10px;
   /* box-shadow: 2px 2px 1px rgba(0, 0, 0, 0.2); */
   background-color: transparent;
@@ -429,33 +426,39 @@ export default {
 
 .icon {
   z-index: 1000;
-  font-size: 15px !important;
+  font-size: 27px !important;
 }
-
 .Condition {
   z-index: 1000;
   position: absolute;
   font-family: 'Roboto', sans-serif;
   font-weight: 100;
-  font-size: 20px;
-  left: 20px;
-  top: 10px;
+  font-size: 14px;
+  right: 20px;
+  top: 22px;
+  text-align: center;
+}
+.Condition p {
+  margin-bottom: 0;
+  font-size: 11px;
+  margin-top: 0;
 }
 
 .Temp {
   z-index: 1000;
   position: absolute;
   font-family: 'Roboto', sans-serif;
-  font-size: 35px;
+  font-size: 45px;
   font-weight: 400;
-  left: 20px;
-  bottom: 5px;
+  right: 60px;
+  bottom: 10px;
+  display: flex;
 }
 
 #F {
   z-index: 1000;
   font-family: 'Roboto', sans-serif;
-  font-weight: 100;
+  font-weight: 150;
   font-size: 30px;
 }
 
@@ -463,15 +466,15 @@ export default {
   z-index: 1000;
   position: absolute;
   font-family: 'Noto Sans', sans-serif;
-  font-size: 18px;
-  font-weight: 200;
+  font-size: 12px;
+  font-weight: 100;
   right: 20px;
-  top: 10px;
+  bottom: 62px;
 }
 
 .locationIcon {
   z-index: 1000;
-  font-size: 15px;
+  font-size: 10px;
   color: white;
 }
 
@@ -479,17 +482,17 @@ export default {
   z-index: 1000;
   position: absolute;
   font-family: 'Noto Sans', sans-serif;
-  font-size: 18px;
+  font-size: 14px;
   font-weight: 200;
   right: 20px;
-  bottom: 15px;
+  bottom: 0px;
   cursor: pointer;
 }
 .locationInput {
   z-index: 1000;
   position: absolute;
   right: 20px;
-  bottom: 15px;
+  bottom: 5px;
 }
 @media (max-width: 1024px) {
   .main {

--- a/client/src/views/Momentum.vue
+++ b/client/src/views/Momentum.vue
@@ -20,10 +20,7 @@
           </div>
         </div>
         <div class="col-3 offset-7">
-          <weather
-            @mouseover.native="revealWeather"
-            @mouseleave.native="hideWeather"
-          />
+          <weather />
         </div>
         <div class="col-1">
           <!-- <calculator /> -->
@@ -33,7 +30,7 @@
     </div>
     <div class="container-fluid middle">
       <div class="row">
-        <div class="col-6 offset-3">
+        <div class="col-6 offset-3 mt-4">
           <clock />
           <greeting />
         </div>
@@ -205,16 +202,16 @@ export default {
       this.showQuoteModal = false;
     },
     // Weather control
-    revealWeather() {
-      console.log('I am revealed');
-      this.showWeatherColor = true;
-      this.$root.$emit('revealWeather');
-    },
-    hideWeather() {
-      console.log('I am hidden');
-      this.showWeatherColor = false;
-      this.$root.$emit('hideWeather');
-    },
+    // revealWeather() {
+    //   console.log('I am revealed');
+    //   this.showWeatherColor = true;
+    //   this.$root.$emit('revealWeather');
+    // },
+    // hideWeather() {
+    //   console.log('I am hidden');
+    //   this.showWeatherColor = false;
+    //   this.$root.$emit('hideWeather');
+    // },
     // News Modal control
     toggleNews() {
       if (this.toggledNews == true) {
@@ -325,13 +322,13 @@ export default {
 }
 p.utilities {
   color: white;
-  font-size: 20px;
+  font-size: 1.3rem;
   text-shadow: 3px 3px 3px black;
 }
 p.utilities:hover {
   cursor: pointer;
-  font-size: 25px;
-  text-shadow: 5px 5px 3px black;
+  font-size: 1.4rem;
+  text-shadow: 4px 4px 3px black;
 }
 .fade-enter-active,
 .fade-leave-active {


### PR DESCRIPTION
After getting the color of the weather component to be hoverable; I realized that it makes that component to 'flashy' or distracting and so I decided to go with a more streamlined approach like the original Momentum.  I got rid of all color initially, made the parent wrapper element much smaller width wise and removed the location/map marker from in front of the city name, and removed the weather condition description (cloudy, sunny, rain, etc). The final product is a nice simple layout with the date and city name in small text above the temperature and weather condition icon.  I also fiddled with some other component's text-shadow after playing around with the text-shadow for the weather component.  Next step is now to configure the component so that when a user clicks on it a little dropdown/modal will appear and teh 5 day forecast will be displayed; along with the weather condition description for that day and the option to change locations.