### PR TITLE
Finish contacts component

### DIFF
--- a/client/src/components/Utilities/Contacts/AddToContact.vue
+++ b/client/src/components/Utilities/Contacts/AddToContact.vue
@@ -2,106 +2,154 @@
   <div class="optionsWrapper">
     <div class="optionsColumn1">
       <div v-if="HasProperty.lastName == false" class="option">
-        <p><small>Add Last Name</small></p>
-        <input
-          type="text"
-          ref="focusLastName"
-          v-model="newContact.lastName"
-          v-autowidth="{
-            maxWidth: '120px',
-            minWidth: '100px',
-            comfortZone: 5,
-          }"
-        />
+        <p><small @click="toggleAdd('lastName')">Add Last Name</small></p>
+        <div v-if="added.lastName == false" class="inputWrapper">
+          <input
+            type="text"
+            ref="focusLastName"
+            v-model="newContact.lastName"
+            v-on:keyup.enter="finishAdding('lastName')"
+            v-autowidth="{
+              maxWidth: '120px',
+              minWidth: '100px',
+              comfortZone: 5,
+            }"
+          />
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.lastName }}</p>
+        </div>
       </div>
       <div v-if="HasProperty.phone == false" class="option">
-        <p><small>Add Phone</small></p>
-        <input
-          type="text"
-          ref="focusPhone"
-          v-model="newContact.phone"
-          v-autowidth="{
-            maxWidth: '120px',
-            minWidth: '100px',
-            comfortZone: 5,
-          }"
-        />
+        <p><small @click="toggleAdd('phone')">Add Phone</small></p>
+        <div v-if="added.phone == false" class="inputWrapper">
+          <input
+            type="text"
+            ref="focusPhone"
+            v-model="newContact.phone"
+            v-on:keyup.enter="finishAdding('phone')"
+            v-autowidth="{
+              maxWidth: '120px',
+              minWidth: '100px',
+              comfortZone: 5,
+            }"
+          />
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.phone }}</p>
+        </div>
       </div>
       <div v-if="HasProperty.email == false" class="option">
-        <p><small>Add Email</small></p>
-        <input
-          type="text"
-          ref="focusEmail"
-          v-model="newContact.email"
-          v-autowidth="{
-            maxWidth: '160px',
-            minWidth: '100px',
-            comfortZone: 5,
-          }"
-        />
+        <p><small @click="toggleAdd('email')">Add Email</small></p>
+        <div v-if="added.email == false" class="inputWrapper">
+          <input
+            type="text"
+            ref="focusEmail"
+            v-model="newContact.email"
+            v-on:keyup.enter="finishAdding('email')"
+            v-autowidth="{
+              maxWidth: '160px',
+              minWidth: '100px',
+              comfortZone: 5,
+            }"
+          />
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.email }}</p>
+        </div>
       </div>
       <div v-if="HasProperty.notes == false" class="option">
-        <p><small>Add Notes</small></p>
-        <textarea
-          id="addNotesTextArea"
-          rows="3"
-          v-model="newContact.notes"
-        ></textarea>
+        <p><small @click="toggleAdd('notes')">Add Notes</small></p>
+        <div v-if="added.notes == false" class="textAreaWrapper">
+          <textarea
+            id="addNotesTextArea"
+            ref="focusNotes"
+            rows="3"
+            v-model="newContact.notes"
+            v-on:keyup.enter="finishAdding('notes')"
+          ></textarea>
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.notes }}</p>
+        </div>
       </div>
     </div>
     <div class="optionsColumn2">
       <div v-if="HasProperty.address == false" class="option">
-        <p><small>Add Address</small></p>
-        <input
-          type="text"
-          ref="focusAddress"
-          v-model="newContact.address"
-          v-autowidth="{
-            maxWidth: '120px',
-            minWidth: '100px',
-            comfortZone: 5,
-          }"
-        />
+        <p><small @click="toggleAdd('address')">Add Address</small></p>
+        <div v-if="added.address == false" class="inputWrapper">
+          <input
+            type="text"
+            ref="focusAddress"
+            v-model="newContact.address"
+            v-on:keyup.enter="finishAdding('address')"
+            v-autowidth="{
+              maxWidth: '120px',
+              minWidth: '100px',
+              comfortZone: 5,
+            }"
+          />
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.address }}</p>
+        </div>
       </div>
       <div v-if="HasProperty.city == false" class="option">
-        <p><small>Add City</small></p>
-        <input
-          type="text"
-          ref="focusCity"
-          v-model="newContact.city"
-          v-autowidth="{
-            maxWidth: '120px',
-            minWidth: '100px',
-            comfortZone: 5,
-          }"
-        />
+        <p><small @click="toggleAdd('city')">Add City</small></p>
+        <div v-if="added.city == false" class="inputWrapper">
+          <input
+            type="text"
+            ref="focusCity"
+            v-model="newContact.city"
+            v-on:keyup.enter="finishAdding('city')"
+            v-autowidth="{
+              maxWidth: '120px',
+              minWidth: '100px',
+              comfortZone: 5,
+            }"
+          />
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.city }}</p>
+        </div>
       </div>
       <div v-if="HasProperty.state == false" class="option">
-        <p><small>Add State</small></p>
-        <input
-          type="text"
-          ref="focusState"
-          v-model="newContact.state"
-          v-autowidth="{
-            maxWidth: '120px',
-            minWidth: '100px',
-            comfortZone: 5,
-          }"
-        />
+        <p><small @click="toggleAdd('state')">Add State</small></p>
+        <div v-if="added.state == false" class="inputWrapper">
+          <input
+            type="text"
+            ref="focusState"
+            v-model="newContact.state"
+            v-on:keyup.enter="finishAdding('state')"
+            v-autowidth="{
+              maxWidth: '120px',
+              minWidth: '100px',
+              comfortZone: 5,
+            }"
+          />
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.state }}</p>
+        </div>
       </div>
-
       <div v-if="HasProperty.zip == false" class="option">
-        <p><small>Add Zip</small></p>
-        <input
-          type="text"
-          ref="focusZip"
-          v-model="newContact.zip"
-          v-autowidth="{
-            maxWidth: '120px',
-            minWidth: '100px',
-            comfortZone: 5,
-          }"
-        />
+        <p><small @click="toggleAdd('zip')">Add Zip</small></p>
+        <div v-if="added.zip == false" class="inputWrapper">
+          <input
+            type="text"
+            ref="focusZip"
+            v-model="newContact.zip"
+            v-on:keyup.enter="finishAdding('zip')"
+            v-autowidth="{
+              maxWidth: '120px',
+              minWidth: '100px',
+              comfortZone: 5,
+            }"
+          />
+        </div>
+        <div v-else class="addedProperty">
+          <p>{{ newContact.zip }}</p>
+        </div>
       </div>
     </div>
   </div>
@@ -114,6 +162,16 @@ export default {
   data() {
     return {
       newContact: { ...this.contactData },
+      added: {
+        lastName: false,
+        phone: false,
+        email: false,
+        address: false,
+        city: false,
+        state: false,
+        zip: false,
+        notes: false,
+      },
     };
   },
   mounted() {},
@@ -122,7 +180,103 @@ export default {
       return this.property;
     },
   },
-  methods: {},
+  methods: {
+    toggleAdd(field) {
+      switch (field) {
+        case 'lastName':
+          this.$nextTick(() => this.$refs.focusLastName.focus());
+          break;
+        case 'phone':
+          this.$nextTick(() => this.$refs.focusPhone.focus());
+          break;
+        case 'email':
+          this.$nextTick(() => this.$refs.focusEmail.focus());
+          break;
+        case 'address':
+          this.$nextTick(() => this.$refs.focusAddress.focus());
+          break;
+        case 'city':
+          this.$nextTick(() => this.$refs.focusCity.focus());
+          break;
+        case 'state':
+          this.$nextTick(() => this.$refs.focusState.focus());
+          break;
+        case 'zip':
+          this.$nextTick(() => this.$refs.focusZip.focus());
+          break;
+        case 'notes':
+          this.$nextTick(() => this.$refs.focusNotes.focus());
+          break;
+
+        default:
+          this.editContact = false;
+          break;
+      }
+    },
+    finishAdding(field) {
+      switch (field) {
+        case 'lastName':
+          if (this.newContact.lastName) {
+            this.added.lastName = true;
+            this.$emit('added', this.newContact);
+          }
+          break;
+        case 'phone':
+          if (this.newContact.phone) {
+            this.added.phone = true;
+            this.$emit('added', this.newContact);
+          }
+
+          break;
+        case 'email':
+          if (this.newContact.email) {
+            this.added.email = true;
+            this.$emit('added', this.newContact);
+          }
+
+          break;
+        case 'address':
+          if (this.newContact.address) {
+            this.added.address = true;
+            this.$emit('added', this.newContact);
+          }
+
+          break;
+        case 'city':
+          if (this.newContact.city) {
+            this.added.city = true;
+            this.$emit('added', this.newContact);
+          }
+
+          break;
+        case 'state':
+          if (this.newContact.state) {
+            this.added.state = true;
+            this.$emit('added', this.newContact);
+          }
+
+          break;
+        case 'zip':
+          if (this.newContact.zip) {
+            this.added.zip = true;
+            this.$emit('added', this.newContact);
+          }
+
+          break;
+        case 'notes':
+          if (this.newContact.notes) {
+            this.added.notes = true;
+            this.$emit('added', this.newContact);
+          }
+
+          break;
+
+        default:
+          this.editContact = false;
+          break;
+      }
+    },
+  },
 };
 </script>
 
@@ -140,5 +294,13 @@ div.option p {
   margin-bottom: 0;
   width: 80px;
   text-align: start;
+}
+div.inputWrapper {
+  height: 35px;
+  width: 110px;
+}
+div.textAreaWrapper {
+  height: 80px;
+  width: 170px;
 }
 </style>

--- a/client/src/components/Utilities/Contacts/ContactDetail.vue
+++ b/client/src/components/Utilities/Contacts/ContactDetail.vue
@@ -1,101 +1,105 @@
 <template>
   <div v-if="editContact == false" class="detailsWrapper">
-    <div class="detailsRow1">
-      <div class="firstNameWrapper">
-        <div v-if="hasConfirmed == false" class="firstName">
-          <p>{{ contactData.firstName }}</p>
+    <div class="detailsBody">
+      <div class="detailsRow1">
+        <div class="firstNameWrapper">
+          <div v-if="hasConfirmed == false" class="firstName">
+            <p>{{ contactData.firstName }}</p>
+          </div>
+          <div v-else class="confirmed">
+            <p>{{ newContact.firstName }}</p>
+          </div>
         </div>
-        <div v-else class="confirmed">
-          <p>{{ newContact.firstName }}</p>
+        <div class="lastNameWrapper">
+          <div
+            v-if="contactData.lastName && hasConfirmed == false"
+            class="lastName"
+          >
+            <p>{{ contactData.lastName }}</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.lastName }}</p>
+          </div>
         </div>
       </div>
-      <div class="lastNameWrapper">
-        <div
-          v-if="contactData.lastName && hasConfirmed == false"
-          class="lastName"
-        >
-          <p>{{ contactData.lastName }}</p>
+      <div class="detailsRow2">
+        <div class="phoneWrapper">
+          <div v-if="contactData.phone && hasConfirmed == false" class="phone">
+            <p>{{ contactData.phone }}</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.phone }}</p>
+          </div>
         </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.lastName }}</p>
+        <div class="emailWrapper">
+          <div v-if="contactData.email && hasConfirmed == false" class="email">
+            <p>{{ contactData.email }}</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.email }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="detailsRow3">
+        <div class="addressWrapper">
+          <div
+            v-if="contactData.address && hasConfirmed == false"
+            class="address"
+          >
+            <p>{{ contactData.address }}</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.address }}</p>
+          </div>
+        </div>
+        <div class="cityWrapper">
+          <div v-if="contactData.city && hasConfirmed == false" class="city">
+            <p>{{ contactData.city }},</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.city }}</p>
+          </div>
+        </div>
+        <div class="stateWrapper">
+          <div v-if="contactData.state && hasConfirmed == false" class="state">
+            <p>{{ contactData.state }}</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.state }}</p>
+          </div>
+        </div>
+        <div class="zipWrapper">
+          <div v-if="contactData.city && hasConfirmed == false" class="zip">
+            <p>({{ contactData.zip }})</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.zip }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="detailsRow4">
+        <div class="notesWrapper">
+          <div v-if="contactData.notes && hasConfirmed == false" class="notes">
+            <p>{{ contactData.notes }}</p>
+          </div>
+          <div v-else-if="hasConfirmed == true" class="confirmed">
+            <p>{{ newContact.notes }}</p>
+          </div>
         </div>
       </div>
     </div>
-    <div class="detailsRow2">
-      <div class="phoneWrapper">
-        <div v-if="contactData.phone && hasConfirmed == false" class="phone">
-          <p>{{ contactData.phone }}</p>
+    <div class="detailsFooter">
+      <div class="detailsRow5">
+        <div class="backButton">
+          <button class="btn btn-secondary" type="button" @click="back">
+            Back
+          </button>
         </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.phone }}</p>
+        <div class="editButton">
+          <button class="btn btn-primary" type="button" @click="startEditing">
+            Edit
+          </button>
         </div>
-      </div>
-      <div class="emailWrapper">
-        <div v-if="contactData.email && hasConfirmed == false" class="email">
-          <p>{{ contactData.email }}</p>
-        </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.email }}</p>
-        </div>
-      </div>
-    </div>
-    <div class="detailsRow3">
-      <div class="addressWrapper">
-        <div
-          v-if="contactData.address && hasConfirmed == false"
-          class="address"
-        >
-          <p>{{ contactData.address }}</p>
-        </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.address }}</p>
-        </div>
-      </div>
-      <div class="cityWrapper">
-        <div v-if="contactData.city && hasConfirmed == false" class="city">
-          <p>{{ contactData.city }},</p>
-        </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.city }}</p>
-        </div>
-      </div>
-      <div class="stateWrapper">
-        <div v-if="contactData.state && hasConfirmed == false" class="state">
-          <p>{{ contactData.state }}</p>
-        </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.state }}</p>
-        </div>
-      </div>
-      <div class="zipWrapper">
-        <div v-if="contactData.city && hasConfirmed == false" class="zip">
-          <p>({{ contactData.zip }})</p>
-        </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.zip }}</p>
-        </div>
-      </div>
-    </div>
-    <div class="detailsRow4">
-      <div class="notesWrapper">
-        <div v-if="contactData.notes && hasConfirmed == false" class="notes">
-          <p>{{ contactData.notes }}</p>
-        </div>
-        <div v-else-if="hasConfirmed == true" class="confirmed">
-          <p>{{ newContact.notes }}</p>
-        </div>
-      </div>
-    </div>
-    <div class="detailsRow5">
-      <div class="backButton">
-        <button class="btn btn-secondary" type="button" @click="back">
-          Back
-        </button>
-      </div>
-      <div class="editButton">
-        <button class="btn btn-primary" type="button" @click="startEditing">
-          Edit
-        </button>
       </div>
     </div>
   </div>
@@ -150,6 +154,12 @@ export default {
 </script>
 
 <style scoped>
+div.detailsBody {
+  height: 300px;
+}
+div.detailsFooter {
+  height: 55px;
+}
 div.detailsRow1 {
   display: flex;
   font-size: 36px;

--- a/client/src/components/Utilities/Contacts/Contacts.vue
+++ b/client/src/components/Utilities/Contacts/Contacts.vue
@@ -247,8 +247,6 @@ export default {
   width: 475px;
   height: 355px;
 }
-.mainHeader {
-}
 .newContactBtn p {
   display: inline-block;
 }

--- a/client/src/components/Utilities/Contacts/EditContact.vue
+++ b/client/src/components/Utilities/Contacts/EditContact.vue
@@ -1,447 +1,375 @@
 <template>
   <div class="detailsWrapper">
-    <div class="detailsRow1">
-      <div class="firstNameWrapper">
-        <div
-          v-if="edit.firstName == false && hasEdited.firstName == false"
-          class="firstName"
-        >
-          <p>{{ contactData.firstName }}</p>
-          <i @click="switchEdit('firstName')" class="fas fa-edit fa-xs"></i>
+    <div class="detailsBody">
+      <div class="detailsRow1">
+        <div class="firstNameWrapper">
+          <div
+            v-if="edit.firstName == false && hasEdited.firstName == false"
+            class="firstName"
+          >
+            <p>{{ contactData.firstName }}</p>
+            <i @click="switchEdit('firstName')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div v-else-if="edit.firstName == true" class="firstNameEdit">
+            <input
+              type="text"
+              ref="focusFirstName"
+              v-model="newContact.firstName"
+              v-on:keyup.enter="finishEditing('firstName')"
+              v-autowidth="{
+                maxWidth: '140px',
+                minWidth: '80px',
+                comfortZone: 5,
+              }"
+            />
+            <i
+              @click="cancelEditing('firstName')"
+              class="far fa-times-circle"
+            ></i>
+          </div>
+          <div
+            v-else-if="hasEdited.firstName == true && edit.firstName == false"
+            class="editedFirstName"
+          >
+            <p>{{ newContact.firstName }}</p>
+            <i @click="switchEdit('firstName')" class="fas fa-edit fa-xs"></i>
+          </div>
         </div>
-        <div v-else-if="edit.firstName == true" class="firstNameEdit">
-          <input
-            type="text"
-            ref="focusFirstName"
-            v-model="newContact.firstName"
-            v-on:keyup.enter="finishEditing('firstName')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          />
-          <i
-            @click="cancelEditing('firstName')"
-            class="far fa-times-circle"
-          ></i>
-        </div>
-        <div
-          v-else-if="hasEdited.firstName == true && edit.firstName == false"
-          class="editedFirstName"
-        >
-          <p>{{ newContact.firstName }}</p>
-          <i @click="switchEdit('firstName')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-      <div class="lastNameWrapper">
-        <div
-          v-if="
-            contactData.lastName &&
-              edit.lastName == false &&
-              hasEdited.lastName == false
-          "
-          class="lastName"
-        >
-          <p>{{ contactData.lastName }}</p>
-          <i @click="switchEdit('lastName')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div
-          v-else-if="contactData.lastName && edit.lastName == true"
-          class="lastNameEdit"
-        >
-          <input
-            type="text"
-            ref="focusLastName"
-            v-model="newContact.lastName"
-            v-on:keyup.enter="finishEditing('lastName')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          /><i
-            @click="cancelEditing('lastName')"
-            class="far fa-times-circle"
-          ></i>
-        </div>
-        <div
-          v-else-if="hasEdited.lastName == true && edit.lastName == false"
-          class="editedLastName"
-        >
-          <p>{{ newContact.lastName }}</p>
-          <i @click="switchEdit('lastName')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-    </div>
-    <div class="detailsRow2">
-      <div class="phoneWrapper">
-        <div
-          v-if="
-            contactData.phone && edit.phone == false && hasEdited.phone == false
-          "
-          class="phone"
-        >
-          <p>{{ contactData.phone }}</p>
-          <i @click="switchEdit('phone')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div
-          v-else-if="contactData.phone && edit.phone == true"
-          class="phoneEdit"
-        >
-          <input
-            type="text"
-            ref="focusPhone"
-            v-model="newContact.phone"
-            v-on:keyup.enter="finishEditing('phone')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          /><i @click="cancelEditing('phone')" class="far fa-times-circle"></i>
-        </div>
-        <div
-          v-else-if="hasEdited.phone == true && edit.phone == false"
-          class="editedPhone"
-        >
-          <p>{{ newContact.phone }}</p>
-          <i @click="switchEdit('phone')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-      <div class="emailWrapper">
-        <div
-          v-if="
-            contactData.email && edit.email == false && hasEdited.email == false
-          "
-          class="email"
-        >
-          <p>{{ contactData.email }}</p>
-          <i @click="switchEdit('email')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div
-          v-else-if="contactData.email && edit.email == true"
-          class="emailEdit"
-        >
-          <input
-            type="text"
-            ref="focusEmail"
-            v-model="newContact.email"
-            v-on:keyup.enter="finishEditing('email')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          /><i @click="cancelEditing('email')" class="far fa-times-circle"></i>
-        </div>
-        <div
-          v-else-if="hasEdited.email == true && edit.email == false"
-          class="editedEmail"
-        >
-          <p>{{ newContact.email }}</p>
-          <i @click="switchEdit('email')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-    </div>
-    <div class="detailsRow3">
-      <div class="addressWrapper">
-        <div
-          v-if="
-            contactData.address &&
-              edit.address == false &&
-              hasEdited.address == false
-          "
-          class="address"
-        >
-          <p>{{ contactData.address }}</p>
-          <i @click="switchEdit('address')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div
-          v-else-if="contactData.address && edit.address == true"
-          class="phoneEdit"
-        >
-          <input
-            type="text"
-            ref="focusAddress"
-            v-model="newContact.address"
-            v-on:keyup.enter="finishEditing('address')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          /><i
-            @click="cancelEditing('address')"
-            class="far fa-times-circle"
-          ></i>
-        </div>
-        <div
-          v-else-if="hasEdited.address == true && edit.address == false"
-          class="editedAddress"
-        >
-          <p>{{ newContact.address }}</p>
-          <i @click="switchEdit('address')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-      <div class="cityWrapper">
-        <div
-          v-if="
-            contactData.city && edit.city == false && hasEdited.city == false
-          "
-          class="city"
-        >
-          <p>{{ contactData.city }},</p>
-          <i @click="switchEdit('city')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div v-else-if="contactData.city && edit.city == true" class="cityEdit">
-          <input
-            type="text"
-            ref="focusCity"
-            v-model="newContact.city"
-            v-on:keyup.enter="finishEditing('city')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          /><i @click="cancelEditing('city')" class="far fa-times-circle"></i>
-        </div>
-        <div
-          v-else-if="hasEdited.city == true && edit.city == false"
-          class="editedCity"
-        >
-          <p>{{ newContact.city }}</p>
-          <i @click="switchEdit('city')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-      <div class="stateWrapper">
-        <div
-          v-if="
-            contactData.state && edit.state == false && hasEdited.city == false
-          "
-          class="state"
-        >
-          <p>{{ contactData.state }}</p>
-          <i @click="switchEdit('state')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div
-          v-else-if="contactData.state && edit.state == true"
-          class="stateEdit"
-        >
-          <input
-            type="text"
-            ref="focusState"
-            v-model="newContact.state"
-            v-on:keyup.enter="finishEditing('state')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          /><i @click="cancelEditing('state')" class="far fa-times-circle"></i>
-        </div>
-        <div
-          v-else-if="hasEdited.state == true && edit.state == false"
-          class="editedState"
-        >
-          <p>{{ newContact.state }}</p>
-          <i @click="switchEdit('state')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-      <div class="zipWrapper">
-        <div
-          v-if="contactData.zip && edit.zip == false && hasEdited.zip == false"
-          class="zip"
-        >
-          <p>({{ contactData.zip }})</p>
-          <i @click="switchEdit('zip')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div v-else-if="contactData.zip && edit.zip == true" class="zipEdit">
-          <input
-            type="text"
-            ref="focusZip"
-            v-model="newContact.zip"
-            v-on:keyup.enter="finishEditing('zip')"
-            v-autowidth="{
-              maxWidth: '140px',
-              minWidth: '80px',
-              comfortZone: 5,
-            }"
-          /><i @click="cancelEditing('zip')" class="far fa-times-circle"></i>
-        </div>
-        <div
-          v-else-if="hasEdited.zip == true && edit.zip == false"
-          class="editedZip"
-        >
-          <p>{{ newContact.zip }}</p>
-          <i @click="switchEdit('zip')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-    </div>
-    <div class="detailsRow4">
-      <div class="notesWrapper">
-        <div
-          v-if="
-            contactData.notes && edit.notes == false && hasEdited.notes == false
-          "
-          class="notes"
-        >
-          <p>{{ contactData.notes }}</p>
-          <i @click="switchEdit('notes')" class="fas fa-edit fa-xs"></i>
-        </div>
-        <div
-          v-else-if="contactData.notes && edit.notes == true"
-          class="notesEdit"
-        >
-          <textarea
-            id="NotesTextArea"
-            rows="3"
-            v-model="newContact.notes"
-            v-on:keyup.enter="finishEditing('notes')"
-          ></textarea
-          ><i @click="cancelEditing('notes')" class="far fa-times-circle"></i>
-        </div>
-        <div
-          v-else-if="hasEdited.notes == true && edit.notes == false"
-          class="editedNotes"
-        >
-          <p>{{ newContact.notes }}</p>
-          <i @click="switchEdit('notes')" class="fas fa-edit fa-xs"></i>
-        </div>
-      </div>
-    </div>
-    <div class="detailsRow5">
-      <!-- <div class="optionsWrapper">
-        <div class="optionsColumn1">
-          <div v-if="hasProperty.lastName == false" class="option">
-            <p><small>Add Last Name</small></p>
+        <div class="lastNameWrapper">
+          <div
+            v-if="
+              contactData.lastName &&
+                edit.lastName == false &&
+                hasEdited.lastName == false
+            "
+            class="lastName"
+          >
+            <p>{{ contactData.lastName }}</p>
+            <i @click="switchEdit('lastName')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="contactData.lastName && edit.lastName == true"
+            class="lastNameEdit"
+          >
             <input
               type="text"
               ref="focusLastName"
               v-model="newContact.lastName"
+              v-on:keyup.enter="finishEditing('lastName')"
               v-autowidth="{
-                maxWidth: '120px',
-                minWidth: '100px',
+                maxWidth: '140px',
+                minWidth: '80px',
                 comfortZone: 5,
               }"
-            />
+            /><i
+              @click="cancelEditing('lastName')"
+              class="far fa-times-circle"
+            ></i>
           </div>
-          <div v-if="hasProperty.phone == false" class="option">
-            <p><small>Add Phone</small></p>
+          <div
+            v-else-if="hasEdited.lastName == true && edit.lastName == false"
+            class="editedLastName"
+          >
+            <p>{{ newContact.lastName }}</p>
+            <i @click="switchEdit('lastName')" class="fas fa-edit fa-xs"></i>
+          </div>
+        </div>
+      </div>
+      <div class="detailsRow2">
+        <div class="phoneWrapper">
+          <div
+            v-if="
+              contactData.phone &&
+                edit.phone == false &&
+                hasEdited.phone == false
+            "
+            class="phone"
+          >
+            <p>{{ contactData.phone }}</p>
+            <i @click="switchEdit('phone')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="contactData.phone && edit.phone == true"
+            class="phoneEdit"
+          >
             <input
               type="text"
               ref="focusPhone"
               v-model="newContact.phone"
+              v-on:keyup.enter="finishEditing('phone')"
               v-autowidth="{
-                maxWidth: '120px',
-                minWidth: '100px',
+                maxWidth: '140px',
+                minWidth: '80px',
                 comfortZone: 5,
               }"
-            />
+            /><i
+              @click="cancelEditing('phone')"
+              class="far fa-times-circle"
+            ></i>
           </div>
-          <div v-if="hasProperty.email == false" class="option">
-            <p><small>Add Email</small></p>
+          <div
+            v-else-if="hasEdited.phone == true && edit.phone == false"
+            class="editedPhone"
+          >
+            <p>{{ newContact.phone }}</p>
+            <i @click="switchEdit('phone')" class="fas fa-edit fa-xs"></i>
+          </div>
+        </div>
+        <div class="emailWrapper">
+          <div
+            v-if="
+              contactData.email &&
+                edit.email == false &&
+                hasEdited.email == false
+            "
+            class="email"
+          >
+            <p>{{ contactData.email }}</p>
+            <i @click="switchEdit('email')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="contactData.email && edit.email == true"
+            class="emailEdit"
+          >
             <input
               type="text"
               ref="focusEmail"
               v-model="newContact.email"
+              v-on:keyup.enter="finishEditing('email')"
               v-autowidth="{
-                maxWidth: '120px',
-                minWidth: '100px',
+                maxWidth: '140px',
+                minWidth: '80px',
                 comfortZone: 5,
               }"
-            />
+            /><i
+              @click="cancelEditing('email')"
+              class="far fa-times-circle"
+            ></i>
           </div>
-          <div v-if="hasProperty.notes == false" class="option">
-            <p><small>Add Notes</small></p>
-            <textarea
-              id="addNotesTextArea"
-              rows="3"
-              v-model="newContact.notes"
-            ></textarea>
+          <div
+            v-else-if="hasEdited.email == true && edit.email == false"
+            class="editedEmail"
+          >
+            <p>{{ newContact.email }}</p>
+            <i @click="switchEdit('email')" class="fas fa-edit fa-xs"></i>
           </div>
         </div>
-        <div class="optionsColumn2">
-          <div v-if="hasProperty.address == false" class="option">
-            <p><small>Add Address</small></p>
+      </div>
+      <div class="detailsRow3">
+        <div class="addressWrapper">
+          <div
+            v-if="
+              contactData.address &&
+                edit.address == false &&
+                hasEdited.address == false
+            "
+            class="address"
+          >
+            <p>{{ contactData.address }}</p>
+            <i @click="switchEdit('address')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="contactData.address && edit.address == true"
+            class="phoneEdit"
+          >
             <input
               type="text"
               ref="focusAddress"
               v-model="newContact.address"
+              v-on:keyup.enter="finishEditing('address')"
               v-autowidth="{
-                maxWidth: '120px',
-                minWidth: '100px',
+                maxWidth: '140px',
+                minWidth: '80px',
                 comfortZone: 5,
               }"
-            />
+            /><i
+              @click="cancelEditing('address')"
+              class="far fa-times-circle"
+            ></i>
           </div>
-          <div v-if="hasProperty.city == false" class="option">
-            <p><small>Add City</small></p>
+          <div
+            v-else-if="hasEdited.address == true && edit.address == false"
+            class="editedAddress"
+          >
+            <p>{{ newContact.address }}</p>
+            <i @click="switchEdit('address')" class="fas fa-edit fa-xs"></i>
+          </div>
+        </div>
+        <div class="cityWrapper">
+          <div
+            v-if="
+              contactData.city && edit.city == false && hasEdited.city == false
+            "
+            class="city"
+          >
+            <p>{{ contactData.city }},</p>
+            <i @click="switchEdit('city')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="contactData.city && edit.city == true"
+            class="cityEdit"
+          >
             <input
               type="text"
               ref="focusCity"
               v-model="newContact.city"
+              v-on:keyup.enter="finishEditing('city')"
               v-autowidth="{
-                maxWidth: '120px',
-                minWidth: '100px',
+                maxWidth: '140px',
+                minWidth: '80px',
                 comfortZone: 5,
               }"
-            />
+            /><i @click="cancelEditing('city')" class="far fa-times-circle"></i>
           </div>
-          <div v-if="hasProperty.state == false" class="option">
-            <p><small>Add State</small></p>
+          <div
+            v-else-if="hasEdited.city == true && edit.city == false"
+            class="editedCity"
+          >
+            <p>{{ newContact.city }}</p>
+            <i @click="switchEdit('city')" class="fas fa-edit fa-xs"></i>
+          </div>
+        </div>
+        <div class="stateWrapper">
+          <div
+            v-if="
+              contactData.state &&
+                edit.state == false &&
+                hasEdited.city == false
+            "
+            class="state"
+          >
+            <p>{{ contactData.state }}</p>
+            <i @click="switchEdit('state')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="contactData.state && edit.state == true"
+            class="stateEdit"
+          >
             <input
               type="text"
               ref="focusState"
               v-model="newContact.state"
+              v-on:keyup.enter="finishEditing('state')"
               v-autowidth="{
-                maxWidth: '120px',
-                minWidth: '100px',
+                maxWidth: '140px',
+                minWidth: '80px',
                 comfortZone: 5,
               }"
-            />
+            /><i
+              @click="cancelEditing('state')"
+              class="far fa-times-circle"
+            ></i>
           </div>
-
-          <div v-if="hasProperty.zip == false" class="option">
-            <p><small>Add Zip</small></p>
+          <div
+            v-else-if="hasEdited.state == true && edit.state == false"
+            class="editedState"
+          >
+            <p>{{ newContact.state }}</p>
+            <i @click="switchEdit('state')" class="fas fa-edit fa-xs"></i>
+          </div>
+        </div>
+        <div class="zipWrapper">
+          <div
+            v-if="
+              contactData.zip && edit.zip == false && hasEdited.zip == false
+            "
+            class="zip"
+          >
+            <p>({{ contactData.zip }})</p>
+            <i @click="switchEdit('zip')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div v-else-if="contactData.zip && edit.zip == true" class="zipEdit">
             <input
               type="text"
               ref="focusZip"
               v-model="newContact.zip"
+              v-on:keyup.enter="finishEditing('zip')"
               v-autowidth="{
-                maxWidth: '120px',
-                minWidth: '100px',
+                maxWidth: '140px',
+                minWidth: '80px',
                 comfortZone: 5,
               }"
-            />
+            /><i @click="cancelEditing('zip')" class="far fa-times-circle"></i>
+          </div>
+          <div
+            v-else-if="hasEdited.zip == true && edit.zip == false"
+            class="editedZip"
+          >
+            <p>{{ newContact.zip }}</p>
+            <i @click="switchEdit('zip')" class="fas fa-edit fa-xs"></i>
           </div>
         </div>
-      </div> -->
-      <add-to-contact
-        :contactData="newContact"
-        :property="hasProperty"
-        @added="addedProperty"
-      />
+      </div>
+      <div class="detailsRow4">
+        <div class="notesWrapper">
+          <div
+            v-if="
+              contactData.notes &&
+                edit.notes == false &&
+                hasEdited.notes == false
+            "
+            class="notes"
+          >
+            <p>{{ contactData.notes }}</p>
+            <i @click="switchEdit('notes')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="contactData.notes && edit.notes == true"
+            class="notesEdit"
+          >
+            <textarea
+              id="NotesTextArea"
+              rows="3"
+              v-model="newContact.notes"
+              v-on:keyup.enter="finishEditing('notes')"
+            ></textarea
+            ><i @click="cancelEditing('notes')" class="far fa-times-circle"></i>
+          </div>
+          <div
+            v-else-if="hasEdited.notes == true && edit.notes == false"
+            class="editedNotes"
+          >
+            <p>{{ newContact.notes }}</p>
+            <i @click="switchEdit('notes')" class="fas fa-edit fa-xs"></i>
+          </div>
+        </div>
+      </div>
+      <div class="detailsRow5">
+        <add-to-contact
+          :contactData="newContact"
+          :property="hasProperty"
+          @added="addedProperty"
+        />
+      </div>
     </div>
-    <div class="detailsRow6">
-      <div class="backButton">
-        <button class="btn btn-secondary" type="button" @click="stopEditing">
-          Cancel
-        </button>
-      </div>
-      <div class="submitButton">
-        <button
-          id="confirmBtn"
-          class="btn btn-primary"
-          type="button"
-          @click="updateContact"
-        >
-          Confirm
-        </button>
-      </div>
-      <div class="reminder">
-        <p><small>**Don't forget to confirm your changes**</small></p>
+    <div class="detailsFooter">
+      <div class="detailsRow6">
+        <div class="buttons">
+          <div class="backButton">
+            <button
+              class="btn btn-secondary"
+              type="button"
+              @click="stopEditing"
+            >
+              Cancel
+            </button>
+          </div>
+          <div class="submitButton">
+            <button
+              id="confirmBtn"
+              class="btn btn-primary"
+              type="button"
+              @click="updateContact"
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+        <div class="reminder">
+          <p v-show="disabled == false">
+            <small>**Don't forget to confirm your changes**</small>
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -493,6 +421,7 @@ export default {
         zip: false,
         notes: false,
       },
+      disabled: true,
     };
   },
   mounted() {
@@ -531,6 +460,7 @@ export default {
       this.$emit('stopEditing');
       this.newContact = { ...this.contactData };
       document.getElementById('confirmBtn').disabled = false;
+      this.disabled = false;
     },
     switchEdit(field) {
       switch (field) {
@@ -681,6 +611,7 @@ export default {
             this.hasEdited.firstName = true;
             this.edit.firstName = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'lastName':
@@ -688,6 +619,7 @@ export default {
             this.hasEdited.lastName = true;
             this.edit.lastName = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'phone':
@@ -695,6 +627,7 @@ export default {
             this.hasEdited.phone = true;
             this.edit.phone = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'email':
@@ -702,6 +635,7 @@ export default {
             this.hasEdited.email = true;
             this.edit.email = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'address':
@@ -709,6 +643,7 @@ export default {
             this.hasEdited.address = true;
             this.edit.address = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'city':
@@ -716,6 +651,7 @@ export default {
             this.hasEdited.city = true;
             this.edit.city = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'state':
@@ -723,6 +659,7 @@ export default {
             this.hasEdited.state = true;
             this.edit.state = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'zip':
@@ -730,6 +667,7 @@ export default {
             this.hasEdited.zip = true;
             this.edit.zip = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         case 'notes':
@@ -737,6 +675,7 @@ export default {
             this.hasEdited.notes = true;
             this.edit.notes = false;
             document.getElementById('confirmBtn').disabled = false;
+            this.disabled = false;
           }
           break;
         default:
@@ -747,6 +686,7 @@ export default {
     addedProperty(newContact) {
       this.newContact = newContact;
       document.getElementById('confirmBtn').disabled = false;
+      this.disabled = false;
     },
     updateContact() {
       this.$store.dispatch('updateContact', this.newContact);
@@ -759,6 +699,12 @@ export default {
 </script>
 
 <style scoped>
+div.detailsBody {
+  height: 300px;
+}
+div.detailsFooter {
+  height: 55px;
+}
 div.detailsRow1 {
   display: flex;
   font-size: 36px;
@@ -814,6 +760,9 @@ div.detailsRow3 div.zip {
 }
 
 div.detailsRow6 {
+  justify-content: center;
+}
+div.buttons {
   display: flex;
   justify-content: center;
 }

--- a/client/src/components/Utilities/Contacts/EditContact.vue
+++ b/client/src/components/Utilities/Contacts/EditContact.vue
@@ -418,7 +418,11 @@
           </div>
         </div>
       </div> -->
-      <add-to-contact :contactData="newContact" :property="hasProperty" />
+      <add-to-contact
+        :contactData="newContact"
+        :property="hasProperty"
+        @added="addedProperty"
+      />
     </div>
     <div class="detailsRow6">
       <div class="backButton">
@@ -673,55 +677,76 @@ export default {
     finishEditing(field) {
       switch (field) {
         case 'firstName':
-          this.hasEdited.firstName = true;
-          this.edit.firstName = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.firstName) {
+            this.hasEdited.firstName = true;
+            this.edit.firstName = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'lastName':
-          this.hasEdited.lastName = true;
-          this.edit.lastName = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.lastName) {
+            this.hasEdited.lastName = true;
+            this.edit.lastName = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'phone':
-          this.hasEdited.phone = true;
-          this.edit.phone = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.phone) {
+            this.hasEdited.phone = true;
+            this.edit.phone = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'email':
-          this.hasEdited.email = true;
-          this.edit.email = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.email) {
+            this.hasEdited.email = true;
+            this.edit.email = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'address':
-          this.hasEdited.address = true;
-          this.edit.address = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.address) {
+            this.hasEdited.address = true;
+            this.edit.address = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'city':
-          this.hasEdited.city = true;
-          this.edit.city = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.city) {
+            this.hasEdited.city = true;
+            this.edit.city = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'state':
-          this.hasEdited.state = true;
-          this.edit.state = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.state) {
+            this.hasEdited.state = true;
+            this.edit.state = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'zip':
-          this.hasEdited.zip = true;
-          this.edit.zip = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.zip) {
+            this.hasEdited.zip = true;
+            this.edit.zip = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
         case 'notes':
-          this.hasEdited.notes = true;
-          this.edit.notes = false;
-          document.getElementById('confirmBtn').disabled = false;
+          if (this.newContact.notes) {
+            this.hasEdited.notes = true;
+            this.edit.notes = false;
+            document.getElementById('confirmBtn').disabled = false;
+          }
           break;
-
         default:
           this.editContact = false;
           break;
       }
+    },
+    addedProperty(newContact) {
+      this.newContact = newContact;
+      document.getElementById('confirmBtn').disabled = false;
     },
     updateContact() {
       this.$store.dispatch('updateContact', this.newContact);


### PR DESCRIPTION
As it turns out, combining the 'AddToContact' component's data with the 'EditContact' component's data was a lot  easier than I anticipated.  I'm sure it has to do with how I set things up initially but through some initial testing everything seems to be working properly.  A user can add as few or as many properties to an existing contact AND edit existing properties, then submit the combined new updated contact and the app will simultaneously send off the updated contact to the DB and render the 'ContactDetail' component's template with the new contact information (we still have the updated information stored locally within the app so we can render that and show the updated information even though the updated data may not be saved and re-fetched from the DB yet). Then when the user either backs out to the main contact screen or refreshes the details screen, that will trigger a mounted operation to go fetch and then sort all the contacts, which will grab the newly updated contact and so the new information will still be accurately displayed.  Again, I've only done some light testing but so far everything is working at intended.  The only things left to do are to make the components pretty and format them and improve the UI; for example there may be times where you want to remove a certain property or multiple properties, right now there is no mechanism to do so. You can only add/edit a property, you can't delete one. This is something I want to add and there may be some other features or edge cases I want to look at; but the core functionality is complete!