### PR TITLE
Finish contacts component

### DIFF
--- a/client/src/components/Utilities/Contacts/AddToContact.vue
+++ b/client/src/components/Utilities/Contacts/AddToContact.vue
@@ -64,12 +64,13 @@
           <textarea
             id="addNotesTextArea"
             ref="focusNotes"
+            cols="25"
             rows="3"
             v-model="newContact.notes"
             v-on:keyup.enter="finishAdding('notes')"
           ></textarea>
         </div>
-        <div v-else class="addedProperty">
+        <div v-else class="addedPropertyNotes">
           <p>{{ newContact.notes }}</p>
         </div>
       </div>
@@ -298,6 +299,10 @@ div.option p {
   width: 80px;
   text-align: start;
 }
+div.addedProperty p {
+  width: 110px;
+  color: goldenrod;
+}
 div.inputWrapper {
   height: 35px;
   width: 110px;
@@ -305,5 +310,23 @@ div.inputWrapper {
 div.textAreaWrapper {
   height: 80px;
   width: 170px;
+}
+textarea {
+  font-size: 12px;
+  margin-left: -5px;
+}
+div.addedPropertyNotes {
+  max-height: 150px;
+  overflow-y: auto;
+  width: 170px;
+  background-color: rgba(116, 116, 116, 0.534);
+  border: 1pt solid grey;
+  text-align: start;
+  font-size: 13px;
+}
+div.addedPropertyNotes p {
+  width: 165px;
+  padding-left: 3px;
+  color: goldenrod;
 }
 </style>

--- a/client/src/components/Utilities/Contacts/ContactDetail.vue
+++ b/client/src/components/Utilities/Contacts/ContactDetail.vue
@@ -35,10 +35,36 @@
           </div>
         </div>
         <div class="emailWrapper">
-          <div v-if="contactData.email && hasConfirmed == false" class="email">
+          <div
+            v-if="
+              contactData.email && contactData.phone && hasConfirmed == false
+            "
+            class="email"
+          >
             <p>{{ contactData.email }}</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed email">
+          <div
+            v-else-if="newContact.phone && hasConfirmed == true"
+            class="confirmed email"
+          >
+            <p>{{ newContact.email }}</p>
+          </div>
+        </div>
+        <!-- If there is an email, but no phone, we need to push the email all the way to the left.  -->
+        <div class="emailNoPhoneWrapper">
+          <div
+            v-if="
+              contactData.email && !contactData.phone && hasConfirmed == false
+            "
+            class="emailNoPhone"
+          >
+            <p>{{ contactData.email }}</p>
+          </div>
+          <!-- Since someone could add a phone number when editing a contact, this needs to check that there still is no phone in the new updated contact. -->
+          <div
+            v-else-if="!newContact.phone && hasConfirmed == true"
+            class="confirmed emailNoPhone"
+          >
             <p>{{ newContact.email }}</p>
           </div>
         </div>
@@ -51,7 +77,10 @@
           >
             <p>{{ contactData.address }},</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed">
+          <div
+            v-else-if="newContact.address && hasConfirmed == true"
+            class="confirmed"
+          >
             <p>{{ newContact.address }},</p>
           </div>
         </div>
@@ -59,7 +88,10 @@
           <div v-if="contactData.city && hasConfirmed == false" class="city">
             <p>{{ contactData.city }},</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed city">
+          <div
+            v-else-if="newContact.city && hasConfirmed == true"
+            class="confirmed city"
+          >
             <p>{{ newContact.city }},</p>
           </div>
         </div>
@@ -67,15 +99,21 @@
           <div v-if="contactData.state && hasConfirmed == false" class="state">
             <p>{{ contactData.state }}</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed state">
+          <div
+            v-else-if="newContact.state && hasConfirmed == true"
+            class="confirmed state"
+          >
             <p>{{ newContact.state }}</p>
           </div>
         </div>
         <div class="zipWrapper">
-          <div v-if="contactData.city && hasConfirmed == false" class="zip">
+          <div v-if="contactData.zip && hasConfirmed == false" class="zip">
             <p>({{ contactData.zip }})</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed zip">
+          <div
+            v-else-if="newContact.zip && hasConfirmed == true"
+            class="confirmed zip"
+          >
             <p>{{ newContact.zip }}</p>
           </div>
         </div>

--- a/client/src/components/Utilities/Contacts/ContactDetail.vue
+++ b/client/src/components/Utilities/Contacts/ContactDetail.vue
@@ -20,7 +20,7 @@
           >
             <p>{{ contactData.lastName }}</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed">
+          <div v-else-if="hasConfirmed == true" class="confirmed lastName">
             <p>{{ newContact.lastName }}</p>
           </div>
         </div>
@@ -38,7 +38,7 @@
           <div v-if="contactData.email && hasConfirmed == false" class="email">
             <p>{{ contactData.email }}</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed">
+          <div v-else-if="hasConfirmed == true" class="confirmed email">
             <p>{{ newContact.email }}</p>
           </div>
         </div>
@@ -49,25 +49,25 @@
             v-if="contactData.address && hasConfirmed == false"
             class="address"
           >
-            <p>{{ contactData.address }}</p>
+            <p>{{ contactData.address }},</p>
           </div>
           <div v-else-if="hasConfirmed == true" class="confirmed">
-            <p>{{ newContact.address }}</p>
+            <p>{{ newContact.address }},</p>
           </div>
         </div>
         <div class="cityWrapper">
           <div v-if="contactData.city && hasConfirmed == false" class="city">
             <p>{{ contactData.city }},</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed">
-            <p>{{ newContact.city }}</p>
+          <div v-else-if="hasConfirmed == true" class="confirmed city">
+            <p>{{ newContact.city }},</p>
           </div>
         </div>
         <div class="stateWrapper">
           <div v-if="contactData.state && hasConfirmed == false" class="state">
             <p>{{ contactData.state }}</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed">
+          <div v-else-if="hasConfirmed == true" class="confirmed state">
             <p>{{ newContact.state }}</p>
           </div>
         </div>
@@ -75,7 +75,7 @@
           <div v-if="contactData.city && hasConfirmed == false" class="zip">
             <p>({{ contactData.zip }})</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed">
+          <div v-else-if="hasConfirmed == true" class="confirmed zip">
             <p>{{ newContact.zip }}</p>
           </div>
         </div>
@@ -85,7 +85,7 @@
           <div v-if="contactData.notes && hasConfirmed == false" class="notes">
             <p>{{ contactData.notes }}</p>
           </div>
-          <div v-else-if="hasConfirmed == true" class="confirmed">
+          <div v-else-if="hasConfirmed == true" class="confirmed notes">
             <p>{{ newContact.notes }}</p>
           </div>
         </div>
@@ -174,6 +174,9 @@ export default {
 </script>
 
 <style scoped>
+p {
+  margin-bottom: 8px;
+}
 div.detailsBody {
   height: 300px;
 }
@@ -182,10 +185,10 @@ div.detailsFooter {
 }
 div.detailsRow1 {
   display: flex;
-  font-size: 36px;
+  font-size: 33px;
 }
 div.detailsRow1 div.lastName {
-  margin-left: 7px;
+  margin-left: 10px;
 }
 div.firstName,
 div.lastName,
@@ -218,7 +221,7 @@ div.notes i {
 
 div.detailsRow2 {
   display: flex;
-  font-size: 26px;
+  font-size: 25px;
 }
 div.detailsRow2 div.email {
   margin-left: 45px;
@@ -226,7 +229,8 @@ div.detailsRow2 div.email {
 
 div.detailsRow3 {
   display: flex;
-  font-size: 21px;
+  font-size: 20px;
+  margin-bottom: 2px;
 }
 div.detailsRow3 div.city,
 div.detailsRow3 div.state,
@@ -234,8 +238,22 @@ div.detailsRow3 div.zip {
   margin-left: 5px;
 }
 
+div.notes {
+  height: 163px;
+  overflow-y: auto;
+  background-color: rgba(116, 116, 116, 0.534);
+  text-align: start;
+  font-size: 13px;
+}
+div.detailsFooter {
+  padding-top: 15px;
+}
 div.detailsRow5 {
   display: flex;
   justify-content: center;
+}
+div.backButton,
+div.editButton {
+  margin: 0 5px;
 }
 </style>

--- a/client/src/components/Utilities/Contacts/ContactsForm.vue
+++ b/client/src/components/Utilities/Contacts/ContactsForm.vue
@@ -191,9 +191,9 @@ input {
   color: goldenrod;
 }
 input:focus {
-  background-color: transparent;
+  background-color: rgba(116, 116, 116, 0.534);
   border: none;
-  border-bottom: 1pt solid white;
+  border: 1pt solid goldenrod;
   outline: none;
 }
 input::placeholder {

--- a/client/src/components/Utilities/Contacts/EditContact.vue
+++ b/client/src/components/Utilities/Contacts/EditContact.vue
@@ -119,10 +119,23 @@
           <div
             v-if="
               contactData.email &&
+                contactData.phone &&
                 edit.email == false &&
                 hasEdited.email == false
             "
             class="email"
+          >
+            <p>{{ contactData.email }}</p>
+            <i @click="switchEdit('email')" class="fas fa-edit fa-xs"></i>
+          </div>
+          <div
+            v-else-if="
+              contactData.email &&
+                !contactData.phone &&
+                edit.email == false &&
+                hasEdited.email == false
+            "
+            class="emailNoPhone"
           >
             <p>{{ contactData.email }}</p>
             <i @click="switchEdit('email')" class="fas fa-edit fa-xs"></i>
@@ -704,7 +717,7 @@ p {
   margin-bottom: 8px;
 }
 div.detailsBody {
-  height: 300px;
+  height: 285px;
 }
 div.detailsFooter {
   height: 55px;

--- a/client/src/components/Utilities/Contacts/EditContact.vue
+++ b/client/src/components/Utilities/Contacts/EditContact.vue
@@ -165,7 +165,7 @@
             "
             class="address"
           >
-            <p>{{ contactData.address }}</p>
+            <p>{{ contactData.address }},</p>
             <i @click="switchEdit('address')" class="fas fa-edit fa-xs"></i>
           </div>
           <div
@@ -191,7 +191,7 @@
             v-else-if="hasEdited.address == true && edit.address == false"
             class="editedAddress"
           >
-            <p>{{ newContact.address }}</p>
+            <p>{{ newContact.address }},</p>
             <i @click="switchEdit('address')" class="fas fa-edit fa-xs"></i>
           </div>
         </div>
@@ -319,7 +319,8 @@
           >
             <textarea
               id="NotesTextArea"
-              rows="3"
+              cols="55"
+              rows="7"
               v-model="newContact.notes"
               v-on:keyup.enter="finishEditing('notes')"
             ></textarea
@@ -327,7 +328,7 @@
           </div>
           <div
             v-else-if="hasEdited.notes == true && edit.notes == false"
-            class="editedNotes"
+            class="editedNotes notes"
           >
             <p>{{ newContact.notes }}</p>
             <i @click="switchEdit('notes')" class="fas fa-edit fa-xs"></i>
@@ -699,6 +700,9 @@ export default {
 </script>
 
 <style scoped>
+p {
+  margin-bottom: 8px;
+}
 div.detailsBody {
   height: 300px;
 }
@@ -707,10 +711,10 @@ div.detailsFooter {
 }
 div.detailsRow1 {
   display: flex;
-  font-size: 36px;
+  font-size: 33px;
 }
 div.detailsRow1 div.lastName {
-  margin-left: 7px;
+  margin-left: 10px;
 }
 div.firstName,
 div.lastName,
@@ -743,7 +747,7 @@ div.notes i {
 
 div.detailsRow2 {
   display: flex;
-  font-size: 26px;
+  font-size: 25px;
 }
 div.detailsRow2 div.email {
   margin-left: 45px;
@@ -751,19 +755,35 @@ div.detailsRow2 div.email {
 
 div.detailsRow3 {
   display: flex;
-  font-size: 21px;
+  font-size: 20px;
+  margin-bottom: 2px;
 }
 div.detailsRow3 div.city,
 div.detailsRow3 div.state,
 div.detailsRow3 div.zip {
   margin-left: 5px;
 }
-
+div.notes {
+  height: 163px;
+  overflow-y: auto;
+  background-color: rgba(116, 116, 116, 0.534);
+  text-align: start;
+  font-size: 13px;
+}
+textarea {
+  font-size: 14px;
+}
+div.detailsFooter {
+  padding-top: 15px;
+}
 div.detailsRow6 {
   justify-content: center;
 }
 div.buttons {
   display: flex;
   justify-content: center;
+}
+button.btn {
+  margin: 0 5px;
 }
 </style>


### PR DESCRIPTION
I've been restyling and reformatting the ContactDetail, EditContact, and AddToContact components and while they may not look the best (as I am in no way a graphic designer or anything of the sort) I believe it looks and is formatted pretty well. There are probably still some small changes that need to happen but overall it's looking pretty good. Through my testing and fiddling around, I discovered a feature that needs to be implemented. When a user is editing a contact property field, they hit 'enter'  to close the input box finish editing that field.  If the user made a mistake or something happened where they need to change what they entered, there is no way to do that except for canceling the entire edit and then restarting and having to refill all the fields.  So a simple solution would be to just add another 'button' to click to re-select the input field and edit it again. Since the entered input isn't being sent off to the DB until the user hits the 'confrim' button, it is harmless for them to change the input as many times as they want. Also, something to keep in mind while I'm styling and formatting everything, I would eventually like to add in someone's place of work and their social links to their contact info; which may (probably will) require additional reformatting.