### PR TITLE
can delete contact properties

### DIFF
--- a/client/src/components/Utilities/Contacts/ContactDetails2.vue
+++ b/client/src/components/Utilities/Contacts/ContactDetails2.vue
@@ -114,7 +114,10 @@
                 </div>
                 <p>{{ contactData.phone }}</p>
               </div>
-              <div class="confirmed" v-else-if="hasConfirmed == true">
+              <div
+                class="confirmed"
+                v-else-if="hasConfirmed == true && newContact.phone"
+              >
                 <div class="labelGroup">
                   <p class="label">
                     <small
@@ -207,7 +210,9 @@
               <!-- Since someone could add a phone number when editing a contact, this needs to check that there still is no phone in the new updated contact. -->
               <div
                 class="confirmed emailNoPhone"
-                v-else-if="!newContact.phone && hasConfirmed == true"
+                v-else-if="
+                  !newContact.phone && hasConfirmed == true && newContact.email
+                "
               >
                 <div class="labelGroup">
                   <p class="label">
@@ -314,7 +319,7 @@
         </div>
       </div>
       <div class="detailsRow2">
-        <div class="notesWrapper" v-if="contactData.notes">
+        <div class="notesWrapper" v-if="contactData.notes && newContact.notes">
           <div class="labelGroup">
             <p class="label">
               <small
@@ -479,15 +484,19 @@ div.lastNameWrapper {
   max-width: 160px;
   overflow-x: auto;
 }
-div.birthdateWrapper {
-  font-size: 14px;
-  align-self: center;
-  position: absolute;
-  top: 14%;
-  right: 14.5%;
-}
 div.nameBirthdateWrapper {
   height: 55px;
+}
+div.birthdateWrapper {
+  width: 90px;
+  font-size: 14px;
+  position: absolute;
+  top: 14%;
+  right: 11.25%;
+}
+div.birthdateEdit {
+  display: flex;
+  flex-direction: column;
 }
 
 /* Phone/Email/Company styling */

--- a/client/src/components/Utilities/Contacts/Contacts.vue
+++ b/client/src/components/Utilities/Contacts/Contacts.vue
@@ -64,7 +64,7 @@
                   </div>
                   <div class="delete">
                     <i
-                      @click="deleteContact(contact._id)"
+                      @click="deleteContact(contact)"
                       class="fas fa-user-minus fa-xs"
                     ></i>
                   </div>
@@ -251,8 +251,8 @@ export default {
         this.$store.dispatch('filterContacts', name[0]);
       }, 100);
     },
-    deleteContact(id) {
-      this.$store.dispatch('deleteContact', id);
+    deleteContact(contact) {
+      this.$store.dispatch('deleteContact', contact);
     },
   },
 };

--- a/client/src/components/Utilities/Contacts/EditContact2.vue
+++ b/client/src/components/Utilities/Contacts/EditContact2.vue
@@ -37,8 +37,8 @@
                     v-on:keyup.enter="finishEditing('firstName')"
                     v-on:blur="cancelEditing('firstName')"
                     v-autowidth="{
-                      maxWidth: '140px',
-                      minWidth: '80px',
+                      maxWidth: '150px',
+                      minWidth: '50px',
                       comfortZone: 5,
                     }"
                   />
@@ -62,7 +62,10 @@
                       hasEdited.lastName == false
                   "
                 >
-                  <p @click="switchEdit('lastName')">
+                  <p
+                    :class="{ deleted: hasDeleted.lastName }"
+                    @click="switchEdit('lastName')"
+                  >
                     {{ contactData.lastName }}
                   </p>
                 </div>
@@ -78,8 +81,8 @@
                     v-on:keyup.enter="finishEditing('lastName')"
                     v-on:blur="cancelEditing('lastName')"
                     v-autowidth="{
-                      maxWidth: '140px',
-                      minWidth: '80px',
+                      maxWidth: '150px',
+                      minWidth: '50px',
                       comfortZone: 5,
                     }"
                   />
@@ -90,7 +93,13 @@
                     hasEdited.lastName == true && edit.lastName == false
                   "
                 >
-                  <p class="editedLastName" @click="switchEdit('lastName')">
+                  <p
+                    :class="{
+                      edited: hasEdited.lastName,
+                      deleted: hasDeleted.lastName,
+                    }"
+                    @click="switchEdit('lastName')"
+                  >
                     {{ newContact.lastName }}
                   </p>
                 </div>
@@ -121,7 +130,10 @@
                 </p>
               </div>
               <div class="flexWrapper">
-                <p @click="switchEdit('birthdate')">
+                <p
+                  :class="{ deleted: hasDeleted.birthdate }"
+                  @click="switchEdit('birthdate')"
+                >
                   {{ contactData.birthdate }}
                 </p>
               </div>
@@ -176,7 +188,13 @@
                   >
                 </p>
               </div>
-              <p class="editedBirthdate" @click="switchEdit('birthdate')">
+              <p
+                :class="{
+                  edited: hasEdited.birthdate,
+                  deleted: hasDeleted.birthdate,
+                }"
+                @click="switchEdit('birthdate')"
+              >
                 {{ newContact.birthdate }}
               </p>
             </div>
@@ -207,7 +225,12 @@
                     >
                   </p>
                 </div>
-                <p @click="switchEdit('phone')">{{ contactData.phone }}</p>
+                <p
+                  :class="{ deleted: hasDeleted.phone }"
+                  @click="switchEdit('phone')"
+                >
+                  {{ contactData.phone }}
+                </p>
               </div>
               <div
                 v-else-if="contactData.phone && edit.phone == true"
@@ -259,7 +282,13 @@
                     >
                   </p>
                 </div>
-                <p class="editedPhone" @click="switchEdit('phone')">
+                <p
+                  :class="{
+                    edited: hasEdited.phone,
+                    deleted: hasDeleted.phone,
+                  }"
+                  @click="switchEdit('phone')"
+                >
                   {{ newContact.phone }}
                 </p>
               </div>
@@ -313,7 +342,12 @@
                     >
                   </p>
                 </div>
-                <p @click="switchEdit('email')">{{ contactData.email }}</p>
+                <p
+                  :class="{ deleted: hasDeleted.email }"
+                  @click="switchEdit('email')"
+                >
+                  {{ contactData.email }}
+                </p>
               </div>
               <div
                 v-else-if="contactData.email && edit.email == true"
@@ -341,7 +375,7 @@
                   v-on:keyup.enter="finishEditing('email')"
                   v-on:blur="cancelEditing('email')"
                   v-autowidth="{
-                    maxWidth: '140px',
+                    maxWidth: '170px',
                     minWidth: '80px',
                     comfortZone: 5,
                   }"
@@ -366,7 +400,13 @@
                   </p>
                 </div>
 
-                <p class="editedEmail" @click="switchEdit('email')">
+                <p
+                  :class="{
+                    edited: hasEdited.email,
+                    deleted: hasDeleted.email,
+                  }"
+                  @click="switchEdit('email')"
+                >
                   {{ newContact.email }}
                 </p>
               </div>
@@ -422,7 +462,12 @@
                   >
                 </p>
               </div>
-              <p @click="switchEdit('company')">{{ contactData.company }}</p>
+              <p
+                :class="{ deleted: hasDeleted.company }"
+                @click="switchEdit('company')"
+              >
+                {{ contactData.company }}
+              </p>
             </div>
             <div
               v-else-if="contactData.company && edit.company == true"
@@ -471,7 +516,13 @@
                   >
                 </p>
               </div>
-              <p class="editedCompany" @click="switchEdit('company')">
+              <p
+                :class="{
+                  edited: hasEdited.company,
+                  deleted: hasDeleted.company,
+                }"
+                @click="switchEdit('company')"
+              >
                 {{ newContact.company }}
               </p>
             </div>
@@ -500,7 +551,12 @@
                 >
               </p>
             </div>
-            <p @click="switchEdit('address')">{{ contactData.address }}</p>
+            <p
+              :class="{ deleted: hasDeleted.address }"
+              @click="switchEdit('address')"
+            >
+              {{ contactData.address }}
+            </p>
           </div>
           <div
             v-else-if="contactData.address && edit.address == true"
@@ -549,7 +605,13 @@
                 >
               </p>
             </div>
-            <p class="editedAddress" @click="switchEdit('address')">
+            <p
+              :class="{
+                edited: hasEdited.address,
+                deleted: hasDeleted.address,
+              }"
+              @click="switchEdit('address')"
+            >
               {{ newContact.address }}
             </p>
           </div>
@@ -580,7 +642,9 @@
                 hasEdited.notes == false
             "
           >
-            <p>{{ contactData.notes }}</p>
+            <p :class="{ deleted: hasDeleted.notes }">
+              {{ contactData.notes }}
+            </p>
           </div>
           <div
             v-else-if="contactData.notes && edit.notes == true"
@@ -601,7 +665,14 @@
             @click="switchEdit('notes')"
             v-else-if="hasEdited.notes == true && edit.notes == false"
           >
-            <p class="editedNotes">{{ newContact.notes }}</p>
+            <p
+              :class="{
+                edited: hasEdited.notes,
+                deleted: hasDeleted.notes,
+              }"
+            >
+              {{ newContact.notes }}
+            </p>
           </div>
         </div>
       </div>
@@ -672,6 +743,16 @@ export default {
         notes: false,
       },
       hasEdited: {
+        firstName: false,
+        lastName: false,
+        phone: false,
+        email: false,
+        address: false,
+        birthdate: false,
+        company: false,
+        notes: false,
+      },
+      hasDeleted: {
         firstName: false,
         lastName: false,
         phone: false,
@@ -866,6 +947,7 @@ export default {
           if (this.newContact.lastName) {
             this.hasEdited.lastName = true;
             this.edit.lastName = false;
+            this.hasDeleted.lastName = false;
             document.getElementById('confirmBtn').disabled = false;
             this.disabled = false;
           }
@@ -874,6 +956,7 @@ export default {
           if (this.newContact.phone) {
             this.hasEdited.phone = true;
             this.edit.phone = false;
+            this.hasDeleted.phone = false;
             document.getElementById('confirmBtn').disabled = false;
             this.disabled = false;
           }
@@ -882,6 +965,7 @@ export default {
           if (this.newContact.email) {
             this.hasEdited.email = true;
             this.edit.email = false;
+            this.hasDeleted.email = false;
             document.getElementById('confirmBtn').disabled = false;
             this.disabled = false;
           }
@@ -890,6 +974,7 @@ export default {
           if (this.newContact.address) {
             this.hasEdited.address = true;
             this.edit.address = false;
+            this.hasDeleted.address = false;
             document.getElementById('confirmBtn').disabled = false;
             this.disabled = false;
           }
@@ -898,6 +983,7 @@ export default {
           if (this.newContact.company) {
             this.hasEdited.company = true;
             this.edit.company = false;
+            this.hasDeleted.company = false;
             document.getElementById('confirmBtn').disabled = false;
             this.disabled = false;
           }
@@ -906,6 +992,7 @@ export default {
           if (this.newContact.birthdate) {
             this.hasEdited.birthdate = true;
             this.edit.birthdate = false;
+            this.hasDeleted.birthdate = false;
             document.getElementById('confirmBtn').disabled = false;
             this.disabled = false;
           }
@@ -914,10 +1001,61 @@ export default {
           if (this.newContact.notes) {
             this.hasEdited.notes = true;
             this.edit.notes = false;
+            this.hasDeleted.notes = false;
             document.getElementById('confirmBtn').disabled = false;
             this.disabled = false;
           }
           break;
+        default:
+          this.editContact = false;
+          break;
+      }
+    },
+    deleteProperty(field) {
+      switch (field) {
+        case 'lastName': {
+          this.hasDeleted.lastName = true;
+          document.getElementById('confirmBtn').disabled = false;
+          this.disabled = false;
+          break;
+        }
+        case 'phone': {
+          this.hasDeleted.phone = true;
+          document.getElementById('confirmBtn').disabled = false;
+          this.disabled = false;
+          break;
+        }
+        case 'email': {
+          this.hasDeleted.email = true;
+          document.getElementById('confirmBtn').disabled = false;
+          this.disabled = false;
+          break;
+        }
+        case 'address': {
+          this.hasDeleted.address = true;
+          document.getElementById('confirmBtn').disabled = false;
+          this.disabled = false;
+          break;
+        }
+        case 'company': {
+          this.hasDeleted.company = true;
+          document.getElementById('confirmBtn').disabled = false;
+          this.disabled = false;
+          break;
+        }
+        case 'birthdate': {
+          this.hasDeleted.birthdate = true;
+          document.getElementById('confirmBtn').disabled = false;
+          this.disabled = false;
+          break;
+        }
+        case 'notes': {
+          this.hasDeleted.notes = true;
+          document.getElementById('confirmBtn').disabled = false;
+          this.disabled = false;
+          break;
+        }
+
         default:
           this.editContact = false;
           break;
@@ -929,10 +1067,34 @@ export default {
       this.disabled = false;
     },
     updateContact() {
+      this.checkForDeletions();
       this.$store.dispatch('updateContact', this.newContact);
       this.$emit('newContact', this.newContact);
       this.$emit('hasConfirmed');
       this.$emit('stopEditing');
+    },
+    checkForDeletions() {
+      if (this.hasDeleted.lastName) {
+        delete this.newContact.lastName;
+      }
+      if (this.hasDeleted.phone) {
+        delete this.newContact.phone;
+      }
+      if (this.hasDeleted.email) {
+        delete this.newContact.email;
+      }
+      if (this.hasDeleted.birthdate) {
+        delete this.newContact.birthdate;
+      }
+      if (this.hasDeleted.company) {
+        delete this.newContact.company;
+      }
+      if (this.hasDeleted.address) {
+        delete this.newContact.address;
+      }
+      if (this.hasDeleted.notes) {
+        delete this.newContact.notes;
+      }
     },
   },
 };
@@ -986,15 +1148,11 @@ input.XlargeInput {
   font-size: 20px;
 }
 
-p.editedFirstName,
-p.editedLastName,
-p.editedPhone,
-p.editedEmail,
-p.editedCompany,
-p.editedAddress,
-p.editedNotes,
-p.editedBirthdate {
+.edited {
   color: goldenrod;
+}
+.deleted {
+  color: rgb(202, 22, 22);
 }
 
 /* Row 1 styling */
@@ -1018,16 +1176,23 @@ div.lastNameWrapper {
   max-width: 160px;
   overflow-x: auto;
 }
-div.birthdateWrapper {
-  font-size: 14px;
-  align-self: center;
-  position: absolute;
-  top: 14%;
-  right: 13%;
-}
 div.nameBirthdateWrapper {
   height: 55px;
 }
+div.birthdateWrapper {
+  width: 90px;
+  font-size: 14px;
+  position: absolute;
+  top: 14%;
+  right: 11.25%;
+}
+div.birthdateEdit {
+  display: flex;
+  flex-direction: column;
+}
+/* div.birthdateEdit input {
+  margin-left: -10px;
+} */
 
 /* Phone/Email/Company styling */
 div.phoneEmailCompanyWrapper {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1289,13 +1289,15 @@ export default new Vuex.Store({
       });
       commit('setFilteredContacts', letterGroup);
     },
-    async deleteContact({ dispatch, state }, id) {
-      await api.delete('contacts/' + id);
-      await dispatch('getContactsByUserId', state.user.user._id);
-      dispatch('filterContacts', state.contacts.currentLetter);
+    async deleteContact({ dispatch }, contact) {
+      await api.delete('contacts/' + contact._id);
+      dispatch('fetchContacts', contact);
     },
-    async updateContact({ dispatch, state }, contact) {
+    async updateContact({ dispatch }, contact) {
       await api.put('contacts/' + contact._id, contact);
+      dispatch('fetchContacts', contact);
+    },
+    async fetchContacts({ dispatch, state }, contact) {
       await dispatch('getContactsByUserId', contact.userId);
       dispatch('filterContacts', state.contacts.currentLetter);
     },

--- a/server/services/ContactService.js
+++ b/server/services/ContactService.js
@@ -33,11 +33,9 @@ class ContactService {
     }
   }
   async editContact(contact) {
+    console.log('edit', contact);
     try {
-      return await dbContext.Contact.findByIdAndUpdate(
-        { _id: contact._id },
-        contact
-      );
+      return await dbContext.Contact.replaceOne({ _id: contact._id }, contact);
     } catch (error) {
       throw new ErrorResponse(
         `Can't edit contact with id ${contact._id}. ${error}`,
@@ -45,6 +43,76 @@ class ContactService {
       );
     }
   }
+  // NOTE See below
+  // NOTE For some reason, the '$unset' operator for the 'update' operation is not functioning as expected. It isn't doing anything, which according to the MongoDB docs is the intended action when the field that is being passed in, does not exist. However, if you look in the collections in the MongoDB desktop application for this project, you can clearly see that a combination of the different field names (lastName,phone, email, birthdate, company, address and notes) are all present on a Contact document.
+  // NOTE The only condition that is being checked, is what field specifically to remove. Hence the switch statement, which switches on the filed name, which was being passed in as a seperate property of the 'combined' object.  Within the switch, we are trying to match a document's _id in the Contact collection with the _id of the contact we want to remove the field from.  Again, if you look at the documents in the collection in the DB, and find the document you are trying to modify, you can clearly see that the _id's do in fact match; however nothing actually gets modified.  This leads me to believe that the problem lies somewhere within the  {$unset: {fieldName: ""}} section.
+  // NOTE However, if you look at the docs for the $unset operator (found here --> https://docs.mongodb.com/manual/reference/operator/update/unset/#up._S_unset), you can see that you should be able to just specify an optional criteria and then the field name to remove from the object(s) that matcht the criteria.  This is exactly what I am doing below; I am setting the criteria to look for an _id match (which you can clearly see for yourself that they do), and the I'm $unsetting the appropriate field (based on the switch statement's case, which is determined by the 'fieldToRemove' property of the 'combined' object).
+  // NOTE However, no errors are thrown and no actuall modifications are made to any documents in the DB. Since, no errors are thrown, this is what leads me to believe that the designated behavior of not doing anything when the field supposedlly doesn't exist is kicking in. I'm almost certain it's not the criteria _id check, because again you can look at the _id being passed into the function, and then look manually in the DB collection and find the corresponding _id.  I've checked the model and schema for 'Contact' and it does have all the necessary field/properties on it; and the only ones that are required are the firstName and userId properties, but those aren't even an option to delete; so none of the properties that are listed below are reqiured.
+  // NOTE Every single StackOverflow post had the same exact answers, basically they were all slight variations of the same configuration, just with different variable and collection names. For example, some had {mulit: true} because they wanted to remove the fields from all matching docs, some had  upsert() in them in case there was no match, but the syntax for the actual $unset was all the same. Every other random site basically just regurgitated the MongoDB docs.
+  // TODO So my workaround was to just send the old contact's id along with the updated contact without the field to the deleteProperty() method and then within there just use the findByIdAndDelete() method to remove the old contact, and then replace it with the create() method using the new updated contact. I don't particularly like this method, as it could be considered resource heavy as the method is actually performing two DB operations; however, given that $unset doesn't appear to be working for me, this is my workaround for now.
+  // NOTE *************SEE BELOW*****************
+  // So I didn't like the method I described above at all so I searched some more online and found the 'replaceOne' operation, which I have not seen before. Turns out, it does basically exactly what I want, even more so than the $unset operator actually.  Now I have configured the client side so that any modifications (editing and deleting right now) don't actually occur to the DB until the user clicks the 'confirm' button. The only changes the user will see is that the text will change color and display a preview of what the edited field would look like; if they delete a field, the text will turn red, if they edit a field the text will turn gold and the new value will show.  It isn't until they hit the confirm button that the fields are actually removed from the 'newContact' object (the one that holds the changes until it's ready to be sent to the DB), and then sent to the DB.  By manipulating a local (within the component) variable, this will allow the user to make as many changes as they want and then only make one database call; instead of deleting the old contact and then recreating it, we are just replacing it.
+  // async deleteProperty(combined) {
+  //   try {
+  //     console.log('from service', combined);
+  //     switch (combined.fieldToRemove) {
+  //       case 'lastName':
+  //         dbContext.Contact.update(
+  //           { _id: combined.contact._id },
+  //           { $unset: { lastName: '' } }
+  //         );
+  //         break;
+  //       case 'phone':
+  //         dbContext.Contact.update(
+  //           { _id: combined.contact._id },
+  //           { $unset: { phone: '' } }
+  //         );
+  //         break;
+  //       case 'email':
+  //         dbContext.Contact.update(
+  //           { _id: combined.contact._id },
+  //           { $unset: { email: '' } }
+  //         );
+  //         break;
+  //       case 'address':
+  //         dbContext.Contact.update(
+  //           { _id: combined.contact._id },
+  //           { $unset: { address: '' } }
+  //         );
+  //         break;
+  //       case 'company':
+  //         console.log('hit company');
+  //         dbContext.Contact.update(
+  //           { _id: combined.contact._id },
+  //           { $unset: { company: '' } }
+  //         );
+  //         break;
+  //       case 'birthdate':
+  //         dbContext.Contact.update(
+  //           { _id: combined.contact._id },
+  //           { $unset: { birthdate: '' } }
+  //         );
+  //         break;
+  //       case 'notes':
+  //         dbContext.Contact.update(
+  //           { _id: combined.contact._id },
+  //           { $unset: { notes: '' } }
+  //         );
+  //         break;
+
+  //       default:
+  //         throw new ErrorResponse(
+  //           `The 'fieldToRemove' of ${fieldToRemove} does not match any fields on the object.`,
+  //           500
+  //         );
+  //     }
+  //   } catch (error) {
+  //     throw new ErrorResponse(
+  //       `Can't delete the property from contact with id ${contact._id}. ${error}`,
+  //       error.response.status
+  //     );
+  //   }
+  // }
 }
 
 export const contactService = new ContactService();


### PR DESCRIPTION
Do you ever spend so long on one issue and then you finally get it working and you jump out of your seat in euphoria?  That is exactly what happened this morning when I spent a couple hours trying to get MongoDB's '$unset' update operator to work; to no avail.  There were no errors and at the same time nothing was actually happening. I looked at ~10 stack overflow forums ranging from 10 to 2 years ago, they all basically had the same configuration. I read MongoDB's docs, I literally copied their format and changed the variable and collection names; still nothing. Like I said, there were no errors that left clues/breadcrumbs to follow...it just wasn't working.  So I cam up with a real janky and not preferable workaround, so undesirable in fact that I went back to the google and continued my search. Thankfully I found a resource on replaceOne() which I haven't heard about until today; but it actually fits what I'm trying to do a lot better than the '$unset' operator.  

I just wanted to allow user to remove certain fields/properties from different contacts (i.e. remove the 'Company' field when someone loses their job), and the first way of me trying it (where I just removed the field client side and then tried to run 'findByIdAndUpdate()') did not work; the document was not actually getting updated (I have a feeling it's because Mongo was looking at the original document with 7 fields on it, and the document I was trying to pass into it to update it with only had 6 fields, and so even though the '_id's may have matched, since the docs were technically different it couldn't update the original).  That's when I found and tried the '$unset' operator, and you can see more detailed notes about that within the 'ContactService.js' file in the server files.

However, with the discovery of the replaceOne() operation, and some slight configuration of the current update/edit contact method, I am now able to edit fields AND delete fields on the 'newContact' local object (which is a copy of a global contact object) and then send the newContact object off to the server to have it replace it's original in the DB.  This way, only one call actually gets made and all the modifications are made client side, all the server has to do is communicate with the DB (which is then responsible for finding and replacing the document). 