### PR TITLE
Refactor menu modals

### DIFF
--- a/client/src/components/Greeting/Clock.vue
+++ b/client/src/components/Greeting/Clock.vue
@@ -81,7 +81,7 @@ export default {
 
 <style scoped>
 .clock {
-  font-size: 11rem;
+  font-size: 9rem;
   color: white;
   text-align: center;
   text-shadow: 3px 3px 5px black;

--- a/client/src/components/Greeting/Greeting.vue
+++ b/client/src/components/Greeting/Greeting.vue
@@ -49,7 +49,16 @@
   <!-- NOTE Below is template for when there is a user 'logged in' -->
   <div class="greeting " v-else>
     <h1>Good {{ timeOfDay }}, {{ User.user.name }}.</h1>
-    <div class="dropdown">
+    <div class="btn" @click="showMenu">
+      <i class="fas fa-ellipsis-h"></i>
+    </div>
+    <greeting-menu
+      class="greetingMenu"
+      v-if="show.menu"
+      @showMenu="showMenu"
+      @createNewUser="createNewUser"
+    />
+    <!-- <div class="dropdown">
       <div id="dLabel" role="button" data-toggle="dropdown" class="btn">
         <i class="fas fa-ellipsis-h"></i>
       </div>
@@ -84,7 +93,7 @@
           </ul>
         </li>
       </ul>
-    </div>
+    </div> -->
   </div>
 </template>
 
@@ -93,12 +102,18 @@ import VueInputAutoWidth from 'vue-input-autowidth';
 import Swal from 'sweetalert2';
 import Vue from 'vue';
 Vue.use(VueInputAutoWidth);
-
+import GreetingMenu from '@/components/Greeting/GreetingMenu.vue';
 export default {
   name: 'Greeting',
+  components: {
+    GreetingMenu,
+  },
   data() {
     return {
       timeOfDay: 'evening',
+      show: {
+        menu: false,
+      },
       user: {
         name: '',
         militaryTimeSelected: false,
@@ -129,6 +144,9 @@ export default {
     },
   },
   methods: {
+    showMenu() {
+      this.show.menu = !this.show.menu;
+    },
     getTimeOfDay() {
       let hour = new Date().getHours();
       if (hour < 12) {
@@ -198,15 +216,20 @@ export default {
 
 <style scoped>
 .greeting {
-  font-size: 4rem;
   color: white;
   justify-content: center;
   align-items: center;
   display: flex;
+  position: absolute;
+  left: 10%;
+  top: 90%;
+}
+.greetingMenu {
+  position: absolute;
 }
 h1 {
   text-shadow: 3px 3px 5px black;
-  font-size: 64px;
+  font-size: 3.75rem;
 }
 input {
   border: none;

--- a/client/src/components/Greeting/Greeting.vue
+++ b/client/src/components/Greeting/Greeting.vue
@@ -37,7 +37,6 @@
 
 <script>
 import VueInputAutoWidth from 'vue-input-autowidth';
-import Swal from 'sweetalert2';
 import Vue from 'vue';
 Vue.use(VueInputAutoWidth);
 import GreetingMenu from '@/components/Greeting/GreetingMenu.vue';
@@ -119,31 +118,6 @@ export default {
       this.$root.$emit('submitNewUser', user);
       this.user.name = '';
     },
-
-    async getUserById(id) {
-      await this.$store.dispatch('getUserById', id);
-      // Let the Clock component know that the user has changed, and pass in the new user and their time prefernce
-      let newUser = this.$store.state.user.user;
-      this.$root.$emit('changedUser', newUser);
-    },
-    // Third party package called SweetAlerts2
-    deleteUserById(id) {
-      Swal.fire({
-        title: 'Are you sure?',
-        text:
-          "You won't be able to revert this and all saved photos and quotes will also be deleted!",
-        icon: 'warning',
-        showCancelButton: true,
-        confirmButtonColor: '#3085d6',
-        cancelButtonColor: '#d33',
-        confirmButtonText: 'Yes, delete it!',
-      }).then(async (result) => {
-        if (result.isConfirmed) {
-          await this.$store.dispatch('deleteUserById', id);
-          Swal.fire('Deleted!', 'The user has been deleted.', 'success');
-        }
-      });
-    },
     onClickOutside() {
       this.user.name = '';
       this.$store.state.user.noUser = false;
@@ -160,6 +134,8 @@ export default {
   display: flex;
   position: relative;
   height: 200px;
+  max-width: 1200px;
+  margin-top: -5em;
 }
 .greetingMenu {
   position: absolute;

--- a/client/src/components/Greeting/Greeting.vue
+++ b/client/src/components/Greeting/Greeting.vue
@@ -10,41 +10,15 @@
       v-on:keyup.enter="submitNewUser"
       v-autowidth="{ maxWidth: '550px', minWidth: '100px', comfortZone: 30 }"
     />
-    <div class="dropdown" v-if="User.userCount > 0">
-      <div id="dLabel" role="button" data-toggle="dropdown" class="btn">
-        <i class="fas fa-ellipsis-h"></i>
-      </div>
-      <ul
-        class="dropdown-menu multi-level"
-        role="menu"
-        aria-labelledby="dropdownMenu"
-      >
-        <li class="dropdown-submenu" v-if="User.userShowChange">
-          <a tabindex="-1">Change user</a>
-          <ul class="dropdown-menu">
-            <li
-              v-for="user in ChangeUsers"
-              :key="user._id"
-              @click="getUserById(user._id)"
-            >
-              {{ user.name }}
-            </li>
-          </ul>
-        </li>
-        <li class="dropdown-submenu">
-          <a tabindex="-1">Delete user</a>
-          <ul class="dropdown-menu">
-            <li v-for="user in Users" :key="user._id">
-              {{ user.name }}
-              <i
-                class="fas fa-user-times user"
-                @click="deleteUserById(user.id)"
-              ></i>
-            </li>
-          </ul>
-        </li>
-      </ul>
+    <div class="btn" @click="showMenu">
+      <i class="fas fa-ellipsis-h"></i>
     </div>
+    <greeting-menu
+      class="greetingMenu"
+      v-if="show.menu"
+      @showMenu="showMenu"
+      @createNewUser="createNewUser"
+    />
   </div>
   <!-- NOTE Below is template for when there is a user 'logged in' -->
   <div class="greeting " v-else>
@@ -58,42 +32,6 @@
       @showMenu="showMenu"
       @createNewUser="createNewUser"
     />
-    <!-- <div class="dropdown">
-      <div id="dLabel" role="button" data-toggle="dropdown" class="btn">
-        <i class="fas fa-ellipsis-h"></i>
-      </div>
-      <ul
-        class="dropdown-menu multi-level"
-        role="menu"
-        aria-labelledby="dropdownMenu"
-      >
-        <li @click="createNewUser">Create new user</li>
-        <li class="dropdown-submenu" v-if="User.userShowChange">
-          <a tabindex="-1">Change user</a>
-          <ul class="dropdown-menu">
-            <li
-              v-for="user in ChangeUsers"
-              :key="user._id"
-              @click="getUserById(user._id)"
-            >
-              {{ user.name }}
-            </li>
-          </ul>
-        </li>
-        <li class="dropdown-submenu">
-          <a tabindex="-1">Delete user</a>
-          <ul class="dropdown-menu">
-            <li v-for="user in Users" :key="user._id">
-              {{ user.name }}
-              <i
-                class="fas fa-user-times user"
-                @click="deleteUserById(user.id)"
-              ></i>
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </div> -->
   </div>
 </template>
 
@@ -220,14 +158,16 @@ export default {
   justify-content: center;
   align-items: center;
   display: flex;
-  position: absolute;
-  left: 10%;
-  top: 90%;
+  position: relative;
+  height: 200px;
 }
 .greetingMenu {
   position: absolute;
+  right: -5em;
+  bottom: -0.5em;
 }
 h1 {
+  margin-left: 1em;
   text-shadow: 3px 3px 5px black;
   font-size: 3.75rem;
 }
@@ -261,72 +201,5 @@ i:hover {
   cursor: pointer;
   color: white;
   opacity: 1;
-}
-i.user {
-  float: right;
-  color: rgba(255, 0, 0, 0.507);
-  padding-right: 5px;
-}
-i.user:hover {
-  color: red;
-}
-li {
-  padding: 3px 0 3px 5px;
-}
-li:hover {
-  cursor: pointer;
-  background-color: rgb(128, 128, 128, 0.2);
-}
-
-/* NOTE Dropdown settings */
-.dropdown {
-  padding-left: 12px;
-}
-.dropdown-submenu {
-  position: relative;
-}
-
-.dropdown-submenu > .dropdown-menu {
-  top: 0;
-  left: 100%;
-  margin-top: -6px;
-  margin-left: -1px;
-  -webkit-border-radius: 0 6px 6px 6px;
-  -moz-border-radius: 0 6px 6px;
-  border-radius: 0 6px 6px 6px;
-}
-
-.dropdown-submenu:hover > .dropdown-menu {
-  display: block;
-}
-
-.dropdown-submenu > a:after {
-  display: block;
-  content: ' ';
-  float: right;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid;
-  border-width: 5px 0 5px 5px;
-  border-left-color: #ccc;
-  margin-top: 5px;
-  margin-right: -10px;
-}
-
-.dropdown-submenu:hover > a:after {
-  border-left-color: #fff;
-}
-
-.dropdown-submenu.pull-left {
-  float: none;
-}
-
-.dropdown-submenu.pull-left > .dropdown-menu {
-  left: -100%;
-  margin-left: 10px;
-  -webkit-border-radius: 6px 0 6px 6px;
-  -moz-border-radius: 6px 0 6px 6px;
-  border-radius: 6px 0 6px 6px;
 }
 </style>

--- a/client/src/components/Greeting/GreetingMenu.vue
+++ b/client/src/components/Greeting/GreetingMenu.vue
@@ -11,30 +11,37 @@
       <p class="change" @click="toggleMenu('change')">Change User</p>
       <p class="delete" @click="toggleMenu('delete')">Delete User</p>
     </div>
-    <div class="changeMenu" v-show="show.change">
+    <div class="subMenu" v-show="show.change">
       <i class="fas fa-arrow-left back" @click="back"></i>
-      <p
-        v-for="user in ChangeUsers"
-        :key="user._id"
-        @click="getUserById(user._id)"
-      >
-        {{ user.name }}
-      </p>
+      <div class="nameList">
+        <p
+          v-for="user in ChangeUsers"
+          :key="user._id"
+          @click="getUserById(user._id)"
+          class="change"
+        >
+          {{ user.name }}
+        </p>
+      </div>
     </div>
-    <div class="deleteMenu" v-show="show.delete">
+    <div class="subMenu" v-show="show.delete">
       <i class="fas fa-arrow-left back" @click="back"></i>
-      <p
-        v-for="user in Users"
-        :key="user._id"
-        @click="deleteUserById(user._id)"
-      >
-        {{ user.name }}
-      </p>
+      <div class="nameList">
+        <p
+          v-for="user in Users"
+          :key="user._id"
+          @click="deleteUserById(user._id)"
+          class="delete"
+        >
+          {{ user.name }}
+        </p>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
+import Swal from 'sweetalert2';
 export default {
   name: 'GreetingMenuComponent',
   data() {
@@ -97,12 +104,32 @@ export default {
     },
     createNewUser() {
       this.$emit('createNewUser');
+      this.$emit('showMenu');
+      document.removeEventListener('click', this.greetingEventListener, false);
     },
     async getUserById(id) {
       await this.$store.dispatch('getUserById', id);
       // Let the Clock component know that the user has changed, and pass in the new user and their time prefernce
       let newUser = this.$store.state.user.user;
       this.$root.$emit('changedUser', newUser);
+    },
+    // Third party package called SweetAlerts2
+    deleteUserById(id) {
+      Swal.fire({
+        title: 'Are you sure?',
+        text:
+          "You won't be able to revert this and all saved photos and quotes will also be deleted!",
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        confirmButtonText: 'Yes, delete it!',
+      }).then(async (result) => {
+        if (result.isConfirmed) {
+          await this.$store.dispatch('deleteUserById', id);
+          Swal.fire('Deleted!', 'The user has been deleted.', 'success');
+        }
+      });
     },
   },
 };
@@ -118,6 +145,9 @@ div.greetingMenu p {
   font-size: 14px;
   margin: 3px 0 0 6px;
 }
+div.greetingMenu p:first-child {
+  margin-top: 0;
+}
 div.greetingMenu p:hover {
   cursor: pointer;
 }
@@ -130,12 +160,33 @@ p.change:hover {
 p.delete:hover {
   color: red;
 }
+div.topMenu {
+  padding-top: 5px;
+}
+div.subMenu {
+  display: flex;
+}
+div.nameList {
+  flex-direction: column;
+  max-height: 75px;
+  overflow-y: auto;
+  padding-right: 15px;
+  margin-top: 3px;
+}
+div.nameList::-webkit-scrollbar {
+  width: 3px;
+  height: 3px;
+  background-color: rgb(90, 90, 90);
+}
+div.nameList::-webkit-scrollbar-thumb {
+  background: goldenrod;
+}
 i.back {
   font-size: 12px;
-  margin-left: 6px;
-  margin-bottom: 0;
+  margin: 6px 0 0 6px;
+  height: 14px;
 }
-i.back:hover {
+i.back:hover::before {
   color: goldenrod;
   cursor: pointer;
 }

--- a/client/src/components/Greeting/GreetingMenu.vue
+++ b/client/src/components/Greeting/GreetingMenu.vue
@@ -1,0 +1,139 @@
+<template>
+  <div
+    class="greetingMenu"
+    :style="{
+      width: dimensions.width + 'px',
+      height: dimensions.height + 'px',
+    }"
+  >
+    <div class="topMenu" v-if="show.top">
+      <p class="create" @click="createNewUser">Create User</p>
+      <p class="change" @click="toggleMenu('change')">Change User</p>
+      <p class="delete" @click="toggleMenu('delete')">Delete User</p>
+    </div>
+    <div class="changeMenu" v-if="show.change">
+      <i class="fas fa-arrow-left back" @click="back"></i>
+      <p
+        v-for="user in ChangeUsers"
+        :key="user._id"
+        @click="getUserById(user._id)"
+      >
+        {{ user.name }}
+      </p>
+    </div>
+    <div class="deleteMenu" v-if="show.delete">
+      <i class="fas fa-arrow-left back" @click="back"></i>
+      <p
+        v-for="user in Users"
+        :key="user._id"
+        @click="deleteUserById(user._id)"
+      >
+        {{ user.name }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'GreetingMenuComponent',
+  data() {
+    return {
+      show: {
+        top: true,
+        change: false,
+        delete: false,
+      },
+      dimensions: {
+        height: 80,
+        width: 120,
+      },
+    };
+  },
+  mounted() {
+    setTimeout(() => {
+      document.addEventListener('click', this.greetingEventListener, false);
+    }, 1000);
+  },
+  computed: {
+    User() {
+      return this.$store.state.user;
+    },
+    Users() {
+      return this.$store.state.user.users;
+    },
+    ChangeUsers() {
+      return this.$store.state.user.changeUser;
+    },
+  },
+  methods: {
+    greetingEventListener(event) {
+      if (!this.$el.contains(event.target)) {
+        this.$emit('showMenu');
+        document.removeEventListener(
+          'click',
+          this.greetingEventListener,
+          false
+        );
+      }
+    },
+    toggleMenu(menu) {
+      this.show.top = false;
+      if (menu == 'change') {
+        this.show.delete = false;
+        this.show.change = true;
+      } else if (menu == 'delete') {
+        this.show.change = false;
+        this.show.delete = true;
+      }
+    },
+    back() {
+      this.show.delete = false;
+      this.show.change = false;
+      this.show.top = true;
+    },
+    createNewUser() {
+      this.$emit('createNewUser');
+    },
+    async getUserById(id) {
+      await this.$store.dispatch('getUserById', id);
+      // Let the Clock component know that the user has changed, and pass in the new user and their time prefernce
+      let newUser = this.$store.state.user.user;
+      this.$root.$emit('changedUser', newUser);
+    },
+  },
+};
+</script>
+
+<style scoped>
+div.greetingMenu {
+  color: white;
+  background-color: rgba(0, 0, 0, 0.85);
+  border-radius: 6px 6px 6px 6px;
+}
+div.greetingMenu p {
+  font-size: 14px;
+  margin: 3px 0 0 6px;
+}
+div.greetingMenu p:hover {
+  cursor: pointer;
+}
+p.create:hover {
+  color: rgb(5, 185, 5);
+}
+p.change:hover {
+  color: goldenrod;
+}
+p.delete:hover {
+  color: red;
+}
+i.back {
+  font-size: 12px;
+  margin-left: 6px;
+  margin-bottom: 0;
+}
+i.back:hover {
+  color: goldenrod;
+  cursor: pointer;
+}
+</style>

--- a/client/src/components/Greeting/GreetingMenu.vue
+++ b/client/src/components/Greeting/GreetingMenu.vue
@@ -6,12 +6,12 @@
       height: dimensions.height + 'px',
     }"
   >
-    <div class="topMenu" v-if="show.top">
+    <div class="topMenu" v-show="show.top">
       <p class="create" @click="createNewUser">Create User</p>
       <p class="change" @click="toggleMenu('change')">Change User</p>
       <p class="delete" @click="toggleMenu('delete')">Delete User</p>
     </div>
-    <div class="changeMenu" v-if="show.change">
+    <div class="changeMenu" v-show="show.change">
       <i class="fas fa-arrow-left back" @click="back"></i>
       <p
         v-for="user in ChangeUsers"
@@ -21,7 +21,7 @@
         {{ user.name }}
       </p>
     </div>
-    <div class="deleteMenu" v-if="show.delete">
+    <div class="deleteMenu" v-show="show.delete">
       <i class="fas fa-arrow-left back" @click="back"></i>
       <p
         v-for="user in Users"
@@ -53,6 +53,7 @@ export default {
   mounted() {
     setTimeout(() => {
       document.addEventListener('click', this.greetingEventListener, false);
+      console.log('set up');
     }, 1000);
   },
   computed: {
@@ -69,6 +70,8 @@ export default {
   methods: {
     greetingEventListener(event) {
       if (!this.$el.contains(event.target)) {
+        console.log(event.target, 'target');
+        console.log(this.$el, 'element');
         this.$emit('showMenu');
         document.removeEventListener(
           'click',

--- a/client/src/components/Weather/5DayForecast.vue
+++ b/client/src/components/Weather/5DayForecast.vue
@@ -345,6 +345,7 @@ export default {
     // This will add the event listener 1 second after the component is mounted
     setTimeout(() => {
       document.addEventListener('click', this.setupEventListener, false);
+      console.log('set up');
     }, 1000);
   },
   computed: {
@@ -374,6 +375,8 @@ export default {
     // This is the actual event listener, it has to be named in order to properly remove the event listener. It is checking to see if whatever you clicked on is contained within 'this.$el' (which I believe in the context of Vue refers to the current component, in this case the 5DayForecast component), and if it is not within it then close the modal/component and remove the event listener.
     setupEventListener(event) {
       if (!this.$el.contains(event.target)) {
+        console.log(event.target, 'target');
+        console.log(this.$el, 'element');
         this.$emit('closeForecast');
         this.show.today = true;
         document.removeEventListener('click', this.setupEventListener, false);

--- a/client/src/views/Momentum.vue
+++ b/client/src/views/Momentum.vue
@@ -35,8 +35,10 @@
     </div>
     <div class="container-fluid middle">
       <div class="row">
-        <div class="col-6 offset-3 mt-4">
+        <div class="clock">
           <clock />
+        </div>
+        <div class="greeting">
           <greeting />
         </div>
         <photo-modal
@@ -309,6 +311,13 @@ export default {
 }
 .middle {
   height: 63vh;
+}
+.middle .row {
+  flex-direction: column;
+  align-items: center;
+}
+.middle .row .greeting {
+  max-width: 1200px;
 }
 .bottom {
   height: 14vh;

--- a/client/src/views/Momentum.vue
+++ b/client/src/views/Momentum.vue
@@ -315,6 +315,7 @@ export default {
 .middle .row {
   flex-direction: column;
   align-items: center;
+  padding-top: 3em;
 }
 .middle .row .greeting {
   max-width: 1200px;


### PR DESCRIPTION
So I decided to refactor the old-drop down menus for the settings and greeting components. I started with the greeting component as it will be easier/quicker than the settings.  Instead of just having a dropdown within the main Greeting component, I made the menu it's own component.  It was a little tricky getting the eventListener to work; I was using 'v-ifs' which meant that at the exact moment when I 'clicked' (which is what the eventListener was listening to), the target element wasn't actually the exact same as when the eventListener was setup...and therefore the original element did not technically contain the target (clicked) element and so the menu kept closing whenever I clicked inside of it. However, after switching to 'v-shows' (and therefore the elements were always there they were just hidden), the original element contained all the necessary target elements to prevent the menu from closing whenever a user clicked within the menu....long story short use 'v-show' with eventListeners. Once I got that figured out, the only other issue was getting the menu to be positioned in the right spot independent of how long the user's name was (it should always be underneath the ellipses which opens the menu). I tried playing around with some position: relative and position: absolute settings but neither were working as intended; so I decided to take the clock and greeting components out of columns and just make them divs, which with a little playing around works a lot better. Other than that, it was just styling and some formatting chagnes.