### PR TITLE
Finish photo settings start quote settings

### DIFF
--- a/client/src/components/SettingsMenu/Menus/PhotosMenu.vue
+++ b/client/src/components/SettingsMenu/Menus/PhotosMenu.vue
@@ -229,15 +229,19 @@ div.savedPhotosSection h5 {
   text-align: center;
   margin-top: 70px;
 }
-.image {
+div.image {
   margin-top: 7px;
   position: relative;
+  margin-bottom: 7px;
 }
 img {
   height: 100px;
   width: 145px;
   cursor: pointer;
-  padding-bottom: 10px;
+  /* padding-bottom: 10px; */
+}
+img:hover {
+  box-shadow: 0px 0px 10px white;
 }
 div.image i {
   position: absolute;

--- a/client/src/components/SettingsMenu/Menus/PhotosMenu.vue
+++ b/client/src/components/SettingsMenu/Menus/PhotosMenu.vue
@@ -13,20 +13,20 @@
             </p>
           </div>
           <div class="uploadPhotoSection">
-            <button class="btn">Upload Photo +</button>
+            <button class="btn" disabled>Upload Photo +</button>
           </div>
         </div>
         <div class="bottomRow">
           <div class="buttonControls">
             <button @click="getNewPhoto">Get New Photo</button>
             <button @click="savePhoto">Save Photo</button>
-            <button>Choose Photo</button>
-            <button>My Uploads</button>
+            <button @click="switchPhotos('saved')">Choose Photo</button>
+            <button @click="switchPhotos('uploaded')">My Uploads</button>
           </div>
         </div>
       </div>
       <div class="mainSection">
-        <div class="savedPhotosSection">
+        <div class="savedPhotosSection" id="test" v-if="show.savedPhotos">
           <h5 v-if="this.$store.state.photo.savedPhotos.length == 0">
             No saved photos yet, save some and you'll find them here!
           </h5>
@@ -41,7 +41,26 @@
               alt="should be small image"
               @click="selectPhoto(photo._id)"
             />
+            <i class="fas fa-trash-alt" @click="deletePhoto(photo._id)"></i>
           </div>
+        </div>
+        <!-- NOTE Need to setup uploading photos -->
+        <div class="savedPhotosSection" v-if="show.uploadedPhotos">
+          <h5>
+            No uploaded photos yet, add some and you'll find them here!
+          </h5>
+          <!-- <div
+            v-else
+            class="image"
+            v-for="photo in savedPhotos"
+            :key="photo.id"
+          >
+            <img
+              :src="photo.urls.thumbUrl"
+              alt="should be small image"
+              @click="selectPhoto(photo._id)"
+            />
+          </div> -->
         </div>
       </div>
     </div>
@@ -52,13 +71,35 @@
 export default {
   name: 'PhotosMenuComponent',
   data() {
-    return {};
+    return {
+      show: {
+        savedPhotos: true,
+        uploadedPhotos: false,
+      },
+    };
   },
   mounted() {
     this.$store.dispatch(
       'getSavedPhotosByUserId',
       this.$store.state.user.user.id
     );
+    setTimeout(() => {
+      let test = document.getElementById('test');
+      test.addEventListener(
+        'mouseover',
+        function(event) {
+          event.target.style.color = 'red';
+        },
+        false
+      );
+      test.addEventListener(
+        'mouseout',
+        function(event) {
+          event.target.style.color = 'transparent';
+        },
+        false
+      );
+    }, 1000);
   },
   computed: {
     savedPhotos() {
@@ -91,6 +132,18 @@ export default {
     selectPhoto(id) {
       this.$store.dispatch('getPhotoById', id);
     },
+    deletePhoto(id) {
+      this.$store.dispatch('deletePhotoById', id);
+    },
+    switchPhotos(type) {
+      if (type === 'saved') {
+        this.show.savedPhotos = true;
+        this.show.uploadedPhotos = false;
+      } else if (type === 'uploaded') {
+        this.show.savedPhotos = false;
+        this.show.uploadedPhotos = true;
+      }
+    },
   },
 };
 </script>
@@ -102,22 +155,14 @@ div.photosMenuComponent {
 }
 div.content {
   height: 385px;
-  overflow-y: auto;
   width: 505px;
   margin-left: auto;
   margin-top: 5px;
+  color: white;
 }
-div.content::-webkit-scrollbar {
-  width: 5px;
-  height: 5px;
-  background-color: rgb(90, 90, 90);
-}
-div.content::-webkit-scrollbar-thumb {
-  background: goldenrod;
-}
+
 div.topRow {
   display: flex;
-  color: white;
 }
 div.title p {
   font-size: 13px;
@@ -161,6 +206,18 @@ div.buttonControls button {
   border-radius: 6px 6px 6px 6px;
   padding: 4px 6px;
 }
+div.mainSection {
+  max-height: 240px;
+  overflow-y: auto;
+}
+div.mainSection::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+  background-color: rgb(90, 90, 90);
+}
+div.mainSection::-webkit-scrollbar-thumb {
+  background: goldenrod;
+}
 div.savedPhotosSection {
   display: flex;
   width: 500px;
@@ -168,13 +225,27 @@ div.savedPhotosSection {
   justify-content: space-around;
   padding-top: 7px;
 }
+div.savedPhotosSection h5 {
+  text-align: center;
+  margin-top: 70px;
+}
 .image {
   margin-top: 7px;
+  position: relative;
 }
 img {
   height: 100px;
   width: 145px;
   cursor: pointer;
   padding-bottom: 10px;
+}
+div.image i {
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  color: transparent;
+}
+div.image i:hover {
+  cursor: pointer;
 }
 </style>

--- a/client/src/components/SettingsMenu/Menus/QuotesMenu.vue
+++ b/client/src/components/SettingsMenu/Menus/QuotesMenu.vue
@@ -1,0 +1,229 @@
+<template>
+  <div class="quotesMenuComponent">
+    <div class="content">
+      <div class="header">
+        <div class="topRow">
+          <div class="title">
+            <h3>Quotes</h3>
+            <p>
+              Get a new quote everytime you 'log in', or you can save your
+              favorites and select which one you want to view for that session.
+              Coming soon: you will be able to upload your own quotes and select
+              them whenever you want!
+            </p>
+          </div>
+          <div class="uploadQuoteSection">
+            <button class="btn" disabled>Upload Quote +</button>
+          </div>
+        </div>
+        <div class="bottomRow">
+          <div class="buttonControls">
+            <button @click="getNewQuote">Get New Quote</button>
+            <button @click="saveQuote">Save Quote</button>
+            <button @click="switchQuotes('saved')">Choose Quote</button>
+            <button @click="switchQuotes('uploaded')">My Uploads</button>
+          </div>
+        </div>
+      </div>
+      <div class="mainSection">
+        <div class="savedQuotesSection" id="test" v-if="show.savedQuotes">
+          <h5 v-if="this.$store.state.quote.savedQuotes.length == 0">
+            No saved quotes yet, save some and you'll find them here!
+          </h5>
+          <div
+            v-else
+            class="quote"
+            v-for="quote in savedQuotes"
+            :key="quote.id"
+          >
+            <div class="quoteText" @click="selectQuote(quote._id)">
+              <p>{{ quote.quote }}</p>
+              <small>Author: {{ quote.author }}</small>
+            </div>
+            <div class="quoteDeleteIcon">
+              <i class="fas fa-trash-alt" @click="deleteQuote(quote._id)"></i>
+            </div>
+          </div>
+        </div>
+        <!-- NOTE Need to setup uploading Quotes -->
+        <div class="savedQuotesSection" v-if="show.uploadedQuotes">
+          <h5>
+            No uploaded Quotes yet, add some and you'll find them here!
+          </h5>
+          <!-- <div
+            v-else
+            class="image"
+            v-for="photo in savedQuotes"
+            :key="photo.id"
+          >
+            <img
+              :src="photo.urls.thumbUrl"
+              alt="should be small image"
+              @click="selectPhoto(photo._id)"
+            />
+          </div> -->
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'QuotesMenuComponent',
+  data() {
+    return {
+      show: {
+        savedQuotes: true,
+        uploadedQuotes: false,
+      },
+    };
+  },
+  mounted() {
+    this.$store.dispatch(
+      'getSavedQuotesByUserId',
+      this.$store.state.user.user.id
+    );
+  },
+  computed: {
+    savedQuotes() {
+      return this.$store.state.quote.savedQuotes;
+    },
+  },
+  methods: {
+    getNewQuote() {
+      this.$store.dispatch('getQuote');
+    },
+    saveQuote() {
+      let savedQuote = {
+        quote: this.$store.state.quote.quote.quote,
+        author: this.$store.state.quote.quote.author,
+        userId: this.$store.state.user.user.id,
+      };
+      this.$store.dispatch('saveQuote', savedQuote);
+    },
+    selectQuote(id) {
+      this.$store.dispatch('getQuoteById', id);
+    },
+    deleteQuote(id) {
+      this.$store.dispatch('deleteQuote', id);
+    },
+    switchQuotes(type) {
+      if (type === 'saved') {
+        this.show.savedQuotes = true;
+        this.show.uploadedQuotes = false;
+      } else if (type === 'uploaded') {
+        this.show.savedQuotes = false;
+        this.show.uploadedQuotes = true;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+div.quotesMenuComponent {
+  height: 395px;
+  width: 515px;
+}
+div.content {
+  height: 385px;
+  width: 505px;
+  margin-left: auto;
+  margin-top: 5px;
+  color: white;
+}
+
+div.topRow {
+  display: flex;
+}
+div.title p {
+  font-size: 13px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+div.uploadQuoteSection {
+  position: relative;
+}
+div.uploadQuoteSection button {
+  position: absolute;
+  right: 10px;
+  top: 7px;
+  font-size: 12px;
+  background-color: white;
+  border: 1pt solid black;
+  border-radius: 6px 6px 6px 6px;
+  width: 110px;
+  padding: 4px 6px;
+}
+div.bottomRow {
+  text-align: center;
+  position: relative;
+}
+div.bottomRow::after {
+  position: absolute;
+  content: '';
+  width: 85%;
+  height: 2px;
+  right: 40px;
+  background: white;
+}
+div.buttonControls {
+  margin-bottom: 10px;
+}
+div.buttonControls button {
+  margin: 0 5px;
+  font-size: 12px;
+  background-color: white;
+  border: 1pt solid black;
+  border-radius: 6px 6px 6px 6px;
+  padding: 4px 6px;
+}
+div.mainSection {
+  max-height: 240px;
+  overflow-y: auto;
+}
+div.mainSection::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+  background-color: rgb(90, 90, 90);
+}
+div.mainSection::-webkit-scrollbar-thumb {
+  background: goldenrod;
+}
+div.savedQuotesSection {
+  width: 500px;
+  padding-top: 7px;
+}
+div.savedQuotesSection h5 {
+  text-align: center;
+  margin-top: 70px;
+}
+div.quote {
+  display: flex;
+  margin-bottom: 10px;
+}
+div.quoteText {
+  width: 470px;
+}
+div.quoteText p {
+  margin-bottom: -5px;
+}
+div.quoteText p:hover {
+  cursor: pointer;
+  text-shadow: 1px 1px 10px white, 1px 1px 10px white;
+}
+div.quoteText small {
+  color: grey;
+}
+div.quoteText small:hover {
+  color: white;
+}
+div.quoteDeleteIcon {
+  color: rgb(114, 33, 33);
+}
+div.quoteDeleteIcon:hover {
+  cursor: pointer;
+  color: red;
+}
+</style>

--- a/client/src/components/SettingsMenu/Settings2.vue
+++ b/client/src/components/SettingsMenu/Settings2.vue
@@ -24,6 +24,7 @@
         <div class="components">
           <general-menu v-if="show.general" />
           <photos-menu v-if="show.photos" />
+          <quotes-menu v-if="show.quotes" />
         </div>
       </div>
     </div>
@@ -33,17 +34,20 @@
 <script>
 import GeneralMenu from '@/components/SettingsMenu/Menus/GeneralMenu.vue';
 import PhotosMenu from '@/components/SettingsMenu/Menus/PhotosMenu.vue';
+import QuotesMenu from '@/components/SettingsMenu/Menus/QuotesMenu.vue';
 export default {
   name: 'Settings2',
   components: {
     GeneralMenu,
     PhotosMenu,
+    QuotesMenu,
   },
   data() {
     return {
       show: {
         general: true,
         photos: false,
+        quotes: false,
       },
     };
   },
@@ -69,10 +73,17 @@ export default {
         case 'general':
           this.show.general = true;
           this.show.photos = false;
+          this.show.quotes = false;
           break;
         case 'photos':
           this.show.general = false;
           this.show.photos = true;
+          this.show.quotes = false;
+          break;
+        case 'quotes':
+          this.show.general = false;
+          this.show.photos = false;
+          this.show.quotes = true;
           break;
         default:
           this.show.general = true;

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -962,9 +962,9 @@ export default new Vuex.Store({
       let res = await api.get('quotes/' + id);
       commit('setQuote', res.data);
     },
-    async saveQuote({ commit }, savedQuote) {
-      let res = await api.post('quotes', savedQuote);
-      commit('setQuote', res.data);
+    async saveQuote({ dispatch, state }, savedQuote) {
+      await api.post('quotes', savedQuote);
+      dispatch('getSavedQuotesByUserId', state.user.user.id);
     },
     async deleteQuote({ dispatch, state }, id) {
       await api.delete('quotes/' + id);


### PR DESCRIPTION
I added in the deletePhoto functionality to the photosMenu component, I still need to fix/modify how the delete icon is displayed when hovering over a photo but it works for now. For the quotesMenu component, it is the exact same layout as the photosMenu because they are so similar in their actions and how to display their respective data. They both need to get new photos/quotes, save a favorite, choose a saved one, and upload a personal favorite if needed. The other menus will be different because they have fundamentally different actions and uses. I'm not complaining though, it made this go by a little bit quicker.  Next I am going to work on the general menu I think.