### PR TITLE
Menus general clock weather

### DIFF
--- a/client/src/components/Greeting/Clock.vue
+++ b/client/src/components/Greeting/Clock.vue
@@ -28,16 +28,16 @@ export default {
 
     // These come from the Greeting component when the user is switched, and so user preference is switched
     this.$root.$on('checkLastUser', (result) => {
-      if (result.militaryTimeSelected == true) {
+      if (result.selected.militaryTime == true) {
         this.militaryTimeSelected = true;
-      } else if (result.militaryTimeSelected == false) {
+      } else if (result.selected.militaryTime == false) {
         this.militaryTimeSelected = false;
       }
     });
     this.$root.$on('changedUser', (newUser) => {
-      if (newUser.militaryTimeSelected == true) {
+      if (newUser.selected.militaryTime == true) {
         this.militaryTimeSelected = true;
-      } else if (newUser.militaryTimeSelected == false) {
+      } else if (newUser.selected.militaryTime == false) {
         this.militaryTimeSelected = false;
       }
     });

--- a/client/src/components/Greeting/Greeting.vue
+++ b/client/src/components/Greeting/Greeting.vue
@@ -53,12 +53,17 @@ export default {
       },
       user: {
         name: '',
-        militaryTimeSelected: false,
-        calculatorSelected: false,
-        newsSelected: false,
-        gamesSelected: false,
         createdTodoLists: [],
         contacts: [],
+        selected: {
+          militaryTime: false,
+          calculator: false,
+          news: false,
+          games: false,
+          weather: true,
+          utilities: true,
+          quote: true,
+        },
       },
     };
   },
@@ -112,8 +117,9 @@ export default {
       this.user.name = '';
       this.$nextTick(() => this.$refs.focus.focus());
     },
-    submitNewUser() {
-      this.$store.dispatch('newUser', this.user);
+    async submitNewUser() {
+      await this.$store.dispatch('updateUserById', this.$store.state.user.user);
+      await this.$store.dispatch('newUser', this.user);
       let user = this.user;
       this.$root.$emit('submitNewUser', user);
       this.user.name = '';

--- a/client/src/components/SettingsMenu/Menus/General/GeneralCustomization.vue
+++ b/client/src/components/SettingsMenu/Menus/General/GeneralCustomization.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="fontControlSection">
       <div class="controls">
-        <div class="label"><b>Font</b></div>
+        <div class="label">Font</div>
         <div class="fonts">
           <div class="topRow">
             <div class="fontOption default" @click="changeFont('default')">
@@ -38,9 +38,7 @@
     </div>
     <div class="themeControlSection">
       <div class="controls">
-        <div class="label comingSoon">
-          <b>Theme</b><small>**Coming Soon**</small>
-        </div>
+        <div class="label comingSoon">Theme<small>**Coming Soon**</small></div>
         <div class="dropleft">
           <button
             class="btn dropdown-toggle"

--- a/client/src/components/SettingsMenu/Menus/General/GeneralMenu.vue
+++ b/client/src/components/SettingsMenu/Menus/General/GeneralMenu.vue
@@ -20,9 +20,13 @@
                 <input
                   type="checkbox"
                   class="custom-control-input"
-                  id="customSwitch1"
+                  id="utilitiesSwitch"
+                  @input="showComponents('utilities')"
                 />
-                <label class="custom-control-label" for="customSwitch1"></label>
+                <label
+                  class="custom-control-label"
+                  for="utilitiesSwitch"
+                ></label>
               </div>
             </div>
             <div class="toggleOption">
@@ -31,9 +35,10 @@
                 <input
                   type="checkbox"
                   class="custom-control-input"
-                  id="customSwitch2"
+                  id="weatherSwitch"
+                  @input="showComponents('weather')"
                 />
-                <label class="custom-control-label" for="customSwitch2"></label>
+                <label class="custom-control-label" for="weatherSwitch"></label>
               </div>
             </div>
             <div class="toggleOption">
@@ -42,9 +47,10 @@
                 <input
                   type="checkbox"
                   class="custom-control-input"
-                  id="customSwitch3"
+                  id="quoteSwitch"
+                  @input="showComponents('quote')"
                 />
-                <label class="custom-control-label" for="customSwitch3"></label>
+                <label class="custom-control-label" for="quoteSwitch"></label>
               </div>
             </div>
             <div class="toggleOption">
@@ -53,9 +59,10 @@
                 <input
                   type="checkbox"
                   class="custom-control-input"
-                  id="customSwitch4"
+                  id="newsSwitch"
+                  @input="showComponents('news')"
                 />
-                <label class="custom-control-label" for="customSwitch4"></label>
+                <label class="custom-control-label" for="newsSwitch"></label>
               </div>
             </div>
             <div class="toggleOption">
@@ -64,9 +71,10 @@
                 <input
                   type="checkbox"
                   class="custom-control-input"
-                  id="customSwitch5"
+                  id="calcSwitch"
+                  @input="showComponents('calc')"
                 />
-                <label class="custom-control-label" for="customSwitch5"></label>
+                <label class="custom-control-label" for="calcSwitch"></label>
               </div>
             </div>
             <div class="toggleOption">
@@ -75,9 +83,10 @@
                 <input
                   type="checkbox"
                   class="custom-control-input"
-                  id="customSwitch6"
+                  id="gamesSwitch"
+                  @input="showComponents('games')"
                 />
-                <label class="custom-control-label" for="customSwitch6"></label>
+                <label class="custom-control-label" for="gamesSwitch"></label>
               </div>
             </div>
           </div>
@@ -93,6 +102,69 @@ export default {
   name: 'GeneralMenuComponent',
   components: {
     GeneralCustomization,
+  },
+  props: ['componentData'],
+  data() {
+    return {
+      show: { ...this.componentData },
+    };
+  },
+  mounted() {
+    this.checkComponents();
+  },
+  computed: {
+    ComponentData() {
+      return this.componentData;
+    },
+  },
+  methods: {
+    checkComponents() {
+      if (this.ComponentData.weather == true) {
+        document
+          .getElementById('weatherSwitch')
+          .setAttribute('checked', 'checked');
+      } else if (this.ComponentData.weather == false) {
+        document.getElementById('weatherSwitch').removeAttribute('checked');
+      }
+      if (this.ComponentData.quote == true) {
+        document
+          .getElementById('quoteSwitch')
+          .setAttribute('checked', 'checked');
+      } else if (this.ComponentData.quote == false) {
+        document.getElementById('quoteSwitch').removeAttribute('checked');
+      }
+      if (this.ComponentData.utilities == true) {
+        document
+          .getElementById('utilitiesSwitch')
+          .setAttribute('checked', 'checked');
+      } else if (this.ComponentData.utilities == false) {
+        document.getElementById('utilitiesSwitch').removeAttribute('checked');
+      }
+      if (this.ComponentData.news == true) {
+        document
+          .getElementById('newsSwitch')
+          .setAttribute('checked', 'checked');
+      } else if (this.ComponentData.news == false) {
+        document.getElementById('newsSwitch').removeAttribute('checked');
+      }
+      if (this.ComponentData.games == true) {
+        document
+          .getElementById('gamesSwitch')
+          .setAttribute('checked', 'checked');
+      } else if (this.ComponentData.games == false) {
+        document.getElementById('gamesSwitch').removeAttribute('checked');
+      }
+      if (this.ComponentData.calculator == true) {
+        document
+          .getElementById('calcSwitch')
+          .setAttribute('checked', 'checked');
+      } else if (this.ComponentData.calculator == false) {
+        document.getElementById('calcSwitch').removeAttribute('checked');
+      }
+    },
+    showComponents(component) {
+      this.$root.$emit('showComponents', component);
+    },
   },
 };
 </script>

--- a/client/src/components/SettingsMenu/Menus/General/GeneralMenu.vue
+++ b/client/src/components/SettingsMenu/Menus/General/GeneralMenu.vue
@@ -164,6 +164,7 @@ export default {
     },
     showComponents(component) {
       this.$root.$emit('showComponents', component);
+      this.$emit('madeChange');
     },
   },
 };

--- a/client/src/components/SettingsMenu/Settings2.vue
+++ b/client/src/components/SettingsMenu/Settings2.vue
@@ -22,7 +22,11 @@
       </div>
       <div class="mainSection">
         <div class="components">
-          <general-menu v-if="show.general" :componentData="showComponents" />
+          <general-menu
+            v-if="show.general"
+            :componentData="showComponents"
+            @madeChange="madeChange"
+          />
           <photos-menu v-if="show.photos" />
           <quotes-menu v-if="show.quotes" />
         </div>
@@ -51,6 +55,7 @@ export default {
         quotes: false,
       },
       showComponents: { ...this.showData },
+      changeMade: false,
     };
   },
   mounted() {
@@ -68,7 +73,14 @@ export default {
           this.settingsEventListener,
           false
         );
+        if (this.changeMade) {
+          console.log('madeChange');
+          this.$store.dispatch('updateUserById', this.$store.state.user.user);
+        }
       }
+    },
+    madeChange() {
+      this.changeMade = true;
     },
     toggleComponent(component) {
       switch (component) {

--- a/client/src/components/SettingsMenu/Settings2.vue
+++ b/client/src/components/SettingsMenu/Settings2.vue
@@ -22,7 +22,7 @@
       </div>
       <div class="mainSection">
         <div class="components">
-          <general-menu v-if="show.general" />
+          <general-menu v-if="show.general" :componentData="showComponents" />
           <photos-menu v-if="show.photos" />
           <quotes-menu v-if="show.quotes" />
         </div>
@@ -42,6 +42,7 @@ export default {
     PhotosMenu,
     QuotesMenu,
   },
+  props: ['showData'],
   data() {
     return {
       show: {
@@ -49,6 +50,7 @@ export default {
         photos: false,
         quotes: false,
       },
+      showComponents: { ...this.showData },
     };
   },
   mounted() {

--- a/client/src/views/Momentum.vue
+++ b/client/src/views/Momentum.vue
@@ -8,22 +8,30 @@
     <div class="container-fluid top">
       <div class="row">
         <div class="col-1">
-          <div v-if="toggledNews" class="toggle" @click="openNewsModal">
-            <i class="far fa-newspaper fa-2x"></i>
-            <p>News</p>
-          </div>
+          <transition name="fade">
+            <div v-if="show.news" class="toggle" @click="openNewsModal">
+              <i class="far fa-newspaper fa-2x"></i>
+              <p>News</p>
+            </div></transition
+          >
         </div>
         <div class="col-1">
-          <div v-if="toggledGames" class="toggle games" @click="openGames">
-            <i class="fas fa-gamepad fa-2x"></i>
-            <p>Games</p>
-          </div>
+          <transition name="fade">
+            <div v-if="show.games" class="toggle games" @click="openGames">
+              <i class="fas fa-gamepad fa-2x"></i>
+              <p>Games</p>
+            </div></transition
+          >
         </div>
         <div class="col-3 offset-7">
-          <div><weather /></div>
+          <transition name="fade">
+            <div v-show="show.weather"><weather /></div
+          ></transition>
         </div>
         <div class="col-1">
-          <calculator v-if="toggledCalculator" class="calculator" />
+          <transition name="fade">
+            <calculator v-if="show.calculator" class="calculator"
+          /></transition>
         </div>
       </div>
     </div>
@@ -41,17 +49,8 @@
             </div>
           </div>
         </div>
-
-        <photo-modal
-          v-if="showPhotoModal"
-          @close-photos-modal="closePhotosModal"
-        />
-        <quote-modal
-          v-if="showQuoteModal"
-          @close-quotes-modal="closeQuotesModal"
-        />
-        <news-modal v-if="showNewsModal" @close-news-modal="closeNewsModal" />
-        <game v-if="showGames" @close-games="closeGames" />
+        <news-modal v-if="toggle.news" @close-news-modal="closeNewsModal" />
+        <game v-if="toggle.games" @close-games="closeGames" />
       </div>
     </div>
     <div class="container-fluid ">
@@ -59,19 +58,28 @@
         <div class="col-1 settingsUtilitiesHeight">
           <p class="toggleMenu" @click="toggleSettings">Settings</p>
           <transition name="fade">
-            <div v-if="show.settings">
-              <settings-2 @toggleSettings="toggleSettings" /></div
+            <div v-if="toggle.settings">
+              <settings-2
+                @toggleSettings="toggleSettings"
+                :showData="show"
+              /></div
           ></transition>
         </div>
         <div class="col-6 offset-2 quote">
-          <quote />
+          <transition name="fade"> <quote v-show="show.quote"/></transition>
         </div>
         <div class="col-1 offset-2 settingsUtilitiesHeight">
-          <p class="toggleMenu text-right" @click="toggleUtilities">
-            Utilities
-          </p>
           <transition name="fade">
-            <div v-if="showUtilities">
+            <p
+              v-show="show.utilities"
+              class="toggleMenu text-right"
+              @click="toggleUtilities"
+            >
+              Utilities
+            </p></transition
+          >
+          <transition name="fade">
+            <div v-if="toggle.utilities">
               <utilities /></div
           ></transition>
         </div>
@@ -82,14 +90,10 @@
 
 <script>
 import Weather from '@/components/Weather/Weather.vue';
-// import Forecast from '@/components/Weather/5DayForecast.vue';
 import Quote from '@/components/Quote.vue';
-// import Settings from '@/components/Settings.vue';
 import Settings2 from '@/components/SettingsMenu/Settings2.vue';
 import Clock from '@/components/Greeting/Clock.vue';
 import Greeting from '@/components/Greeting/Greeting.vue';
-import PhotoModal from '@/components/Modals/PhotoModal.vue';
-import QuoteModal from '@/components/Modals/QuoteModal.vue';
 import Calculator from '@/components/Optional/Calculator/Calculator.vue';
 import NewsModal from '@/components/Modals/NewsModal.vue';
 import Utilities from '@/components/Utilities/UtilitiesComponent.vue';
@@ -100,34 +104,30 @@ export default {
   components: {
     Weather,
     Quote,
-    // Settings,
     Settings2,
     Clock,
     Greeting,
-    PhotoModal,
-    QuoteModal,
     Calculator,
     NewsModal,
     Utilities,
     Game,
-    // Forecast,
   },
   data() {
     return {
-      showPhotoModal: false,
-      showQuoteModal: false,
-      showTodosModal: false,
-      toggledCalculator: false,
-      showCalculator: false,
-      toggledNews: false,
-      showNewsModal: false,
-      toggledGames: false,
-      showGames: false,
-      showUtilities: false,
-      show5DayForecast: false,
       gotPhoto: false,
       show: {
+        utilities: true,
+        weather: true,
+        quote: true,
+        calculator: false,
+        news: false,
+        games: false,
+      },
+      toggle: {
         settings: false,
+        utilities: false,
+        news: false,
+        games: false,
       },
     };
   },
@@ -149,6 +149,9 @@ export default {
       this.checkNews(user);
       this.checkGames(user);
     });
+    this.$root.$on('showComponents', (component) => {
+      this.showComponents(component);
+    });
   },
   computed: {
     Photo() {
@@ -156,111 +159,91 @@ export default {
     },
   },
   methods: {
+    showComponents(component) {
+      switch (component) {
+        case 'weather':
+          this.show.weather = !this.show.weather;
+          break;
+        case 'utilities':
+          this.show.utilities = !this.show.utilities;
+          break;
+        case 'quote':
+          this.show.quote = !this.show.quote;
+          break;
+        case 'news':
+          this.show.news = !this.show.news;
+          break;
+        case 'calc':
+          this.show.calculator = !this.show.calculator;
+          break;
+        case 'games':
+          this.show.games = !this.show.games;
+          break;
+
+        default:
+          this.show.weather = true;
+          this.show.quote = true;
+          this.show.utilities = true;
+          this.show.games = false;
+          this.show.news = false;
+          this.show.calculator = false;
+          break;
+      }
+    },
     async getPhotoBackground() {
       await this.$store.dispatch('getPhoto');
       this.gotPhoto = true;
     },
-    // Photo Modal control
-    openPhotosModal() {
-      this.showPhotoModal = true;
-    },
-    closePhotosModal() {
-      this.showPhotoModal = false;
-    },
-    // Quote Modal control
-    openQuotesModal() {
-      this.showQuoteModal = true;
-    },
-    closeQuotesModal() {
-      this.showQuoteModal = false;
-    },
-    // // Weather control
-    // toggle5DayForecast() {
-    //   if (this.show5DayForecast == true) {
-    //     this.show5DayForecast = false;
-    //   } else if (this.show5DayForecast == false) {
-    //     this.show5DayForecast = true;
-    //   }
-    // },
     // News Modal control
-    toggleNews() {
-      if (this.toggledNews == true) {
-        this.toggledNews = false;
-      } else if (this.toggledNews == false) {
-        this.toggledNews = true;
-      }
-    },
     openNewsModal() {
-      this.showNewsModal = true;
+      this.toggle.news = true;
     },
     closeNewsModal() {
-      this.showNewsModal = false;
+      this.toggle.news = false;
     },
     checkNews(user) {
       if (user.newsSelected == true) {
-        this.toggledNews = true;
+        this.show.news = true;
       } else {
-        this.toggledNews = false;
-      }
-    },
-    // Todos Control
-    toggleTodos() {
-      if (this.showTodosModal == true) {
-        this.showTodosModal = false;
-      } else {
-        this.showTodosModal = true;
+        this.show.news = false;
       }
     },
     // Calculator control
-    toggleCalculator() {
-      if (this.toggledCalculator == false) {
-        this.toggledCalculator = true;
-      } else {
-        this.toggledCalculator = false;
-      }
-    },
     checkCaclulator(user) {
       if (user.calculatorSelected == true) {
-        this.toggledCalculator = true;
+        this.show.calculator = true;
       } else {
-        this.toggledCalculator = false;
+        this.show.calculator = false;
       }
     },
     // Games control
-    toggleGames() {
-      if (this.toggledGames == true) {
-        this.toggledGames = false;
-      } else {
-        this.toggledGames = true;
-      }
-    },
     openGames() {
-      this.showGames = true;
+      this.toggle.games = true;
     },
     closeGames() {
-      this.showGames = false;
+      this.toggle.games = false;
     },
     checkGames(user) {
       if (user.gamesSelected == true) {
-        this.toggledGames = true;
+        this.show.games = true;
       } else {
-        this.toggledGames = false;
+        this.show.games = false;
       }
     },
     // Utilities control
     toggleUtilities() {
-      if (this.showUtilities == false) {
-        this.showUtilities = true;
-      } else if (this.showUtilities == true) {
-        this.showUtilities = false;
+      if (this.toggle.utilities == false) {
+        this.toggle.utilities = true;
+      } else if (this.toggle.utilities == true) {
+        this.toggle.utilities = false;
       }
     },
     // Settings
     toggleSettings() {
-      if (this.show.settings == false) {
-        this.show.settings = true;
-      } else if (this.show.settings == true) {
-        this.show.settings = false;
+      if (this.toggle.settings == false) {
+        this.toggle.settings = true;
+      } else if (this.toggle.settings == true) {
+        this.toggle.settings = false;
       }
     },
   },
@@ -290,12 +273,6 @@ div.middle div.row.greetingRow {
   justify-content: center;
   padding-top: 0;
 }
-/* div.middle div.row div.greetingWrapper {
-  width: 1400px;
-}
-.middle .row .greeting {
-  max-width: 1400px;
-} */
 .bottom {
   height: 14vh;
   align-items: flex-end;

--- a/client/src/views/Momentum.vue
+++ b/client/src/views/Momentum.vue
@@ -137,17 +137,26 @@ export default {
       this.checkCaclulator(result);
       this.checkNews(result);
       this.checkGames(result);
+      this.checkWeather(result);
+      this.checkQuote(result);
+      this.checkUtilities(result);
     });
     this.$root.$on('changedUser', (newUser) => {
       console.log('hit changed user in the momentum view');
       this.checkCaclulator(newUser);
       this.checkNews(newUser);
       this.checkGames(newUser);
+      this.checkWeather(newUser);
+      this.checkQuote(newUser);
+      this.checkUtilities(newUser);
     });
     this.$root.$on('submitNewUser', (user) => {
       this.checkCaclulator(user);
       this.checkNews(user);
       this.checkGames(user);
+      this.checkWeather(user);
+      this.checkQuote(user);
+      this.checkUtilities(user);
     });
     this.$root.$on('showComponents', (component) => {
       this.showComponents(component);
@@ -163,21 +172,27 @@ export default {
       switch (component) {
         case 'weather':
           this.show.weather = !this.show.weather;
+          this.$store.state.user.user.selected.weather = this.show.weather;
           break;
         case 'utilities':
           this.show.utilities = !this.show.utilities;
+          this.$store.state.user.user.selected.utilities = this.show.utilities;
           break;
         case 'quote':
           this.show.quote = !this.show.quote;
+          this.$store.state.user.user.selected.quote = this.show.quote;
           break;
         case 'news':
           this.show.news = !this.show.news;
+          this.$store.state.user.user.selected.news = this.show.news;
           break;
         case 'calc':
           this.show.calculator = !this.show.calculator;
+          this.$store.state.user.user.selected.calculator = this.show.calculator;
           break;
         case 'games':
           this.show.games = !this.show.games;
+          this.$store.state.user.user.selected.games = this.show.games;
           break;
 
         default:
@@ -202,15 +217,36 @@ export default {
       this.toggle.news = false;
     },
     checkNews(user) {
-      if (user.newsSelected == true) {
+      if (user.selected.news == true) {
         this.show.news = true;
       } else {
         this.show.news = false;
       }
     },
+    checkWeather(user) {
+      if (user.selected.weather == true) {
+        this.show.weather = true;
+      } else {
+        this.show.weather = false;
+      }
+    },
+    checkQuote(user) {
+      if (user.selected.quote == true) {
+        this.show.quote = true;
+      } else {
+        this.show.quote = false;
+      }
+    },
+    checkUtilities(user) {
+      if (user.selected.utilities == true) {
+        this.show.utilities = true;
+      } else {
+        this.show.utilities = false;
+      }
+    },
     // Calculator control
     checkCaclulator(user) {
-      if (user.calculatorSelected == true) {
+      if (user.selected.calculator == true) {
         this.show.calculator = true;
       } else {
         this.show.calculator = false;
@@ -224,7 +260,7 @@ export default {
       this.toggle.games = false;
     },
     checkGames(user) {
-      if (user.gamesSelected == true) {
+      if (user.selected.games == true) {
         this.show.games = true;
       } else {
         this.show.games = false;

--- a/server/models/LastUser.js
+++ b/server/models/LastUser.js
@@ -4,11 +4,9 @@ const Schema = mongoose.Schema;
 const LastUser = new Schema(
   {
     name: { type: String, required: true },
-    militaryTimeSelected: { type: Boolean, required: true },
-    calculatorSelected: { type: Boolean, required: true },
-    newsSelected: { type: Boolean, required: true },
-    gamesSelected: { type: Boolean, required: true },
     createdTodoLists: { type: Array, required: true },
+    contacts: { type: Array, required: true },
+    selected: { type: Object, required: true },
   },
   { timestamps: true, toJSON: { virtuals: true } }
 );

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -11,15 +11,12 @@ const _todoRepo = mongoose.model('Todo', Todo);
 const _todoListRepo = mongoose.model('List', TodoList);
 const _contactRepo = mongoose.model('Contact', Contact);
 
-const UserSchema = new mongoose.Schema(
+const UserSchema = new Schema(
   {
     name: { type: String, required: true },
-    militaryTimeSelected: { type: Boolean, required: true },
-    calculatorSelected: { type: Boolean, required: true },
-    newsSelected: { type: Boolean, required: true },
-    gamesSelected: { type: Boolean, required: true },
     createdTodoLists: { type: Array, required: true },
     contacts: { type: Array, required: true },
+    selected: { type: Object, required: true },
   },
   { timestamps: true, toJSON: { virtuals: true } }
 );


### PR DESCRIPTION
So the first thing I did was refactor the main Momentum view, to properly delineate between controls for certain components and/or their togglers and whether they are visible or not AND the actual toggling of the visibility of certain components. Reading that back, it doesn't really make sense, but the key takeaway is that I made a clearer distinction between 'show' and 'toggle'.  Then I setup the functionality for the variables that control the showing to be passed down as props into the Settings component and then into the GeneralMenu component. From there it will dynamically changed which switches are 'checked' or not. From there, I then configured the methods to handle when a user switches one of the switches, sending the data up through 'this.$root.$emit()' up into the main Momentum view. From there, we must then dynamically change the respective booleans that control whether a component/toggler is shown or not. Then I had to refactor the User model to 'save' the user's decision, so that when they reload the app/switch users, it will remember their choices.  I set it up so that whenever they close the Settings component, it will send an update to the server with the new User object that has their stored preferences on it. If they open the Settings component and don't make any changes, no update is sent, to prevent unnecessary calls to the DB.  I have not fully stress tested it, but so far it works as intended. Further testing is needed though.